### PR TITLE
Add configurable audio input/output devices

### DIFF
--- a/OcchioOnniveggente/src/audio.py
+++ b/OcchioOnniveggente/src/audio.py
@@ -161,7 +161,13 @@ def record_until_silence(
     return True
 
 
-def play_and_pulse(path: Path, light: Any, sr: int, lighting_conf: Dict[str, Any]) -> None:
+def play_and_pulse(
+    path: Path,
+    light: Any,
+    sr: int,
+    lighting_conf: Dict[str, Any],
+    output_device_id: Any | None = None,
+) -> None:
     """Play audio file and pulse the given light accordingly."""
     y, sr = load_audio_as_float(path, sr)
     stop = False
@@ -187,7 +193,7 @@ def play_and_pulse(path: Path, light: Any, sr: int, lighting_conf: Dict[str, Any
 
     t = threading.Thread(target=worker, daemon=True)
     t.start()
-    sd.play(y, sr, blocking=True)
+    sd.play(y, sr, blocking=True, device=output_device_id)
     stop = True
     t.join()
 


### PR DESCRIPTION
## Summary
- add `pick_device` helper to resolve audio device ids by name or index
- read `audio.input_device` and `audio.output_device` from settings and set `sd.default.device`
- allow `play_and_pulse` and `record_until_silence` to use chosen devices

## Testing
- `python -m py_compile OcchioOnniveggente/src/main.py OcchioOnniveggente/src/audio.py`


------
https://chatgpt.com/codex/tasks/task_e_68a647e607f88327862aabe15ad0ce4f