### PR TITLE
Add Pydantic settings and profanity filter tests

### DIFF
--- a/OcchioOnniveggente/README.md
+++ b/OcchioOnniveggente/README.md
@@ -1,0 +1,43 @@
+# Occhio Onniveggente
+
+## Configurazione
+
+Le impostazioni dell'applicazione sono definite in `settings.yaml` e vengono caricate tramite
+modelli [Pydantic](https://docs.pydantic.dev/) presenti in `src/config.py`.
+I valori mancanti o non validi vengono segnalati e sostituiti con default sensati.
+
+Esempio di caricamento:
+
+```python
+from pathlib import Path
+from pydantic import ValidationError
+from src.config import Settings
+
+try:
+    settings = Settings.model_validate_yaml(Path("settings.yaml"))
+except ValidationError as e:
+    for err in e.errors():
+        print(f"Errore in {err['loc']}: {err['msg']}")
+    print("Uso impostazioni di default.")
+    settings = Settings()
+```
+
+Un `settings.yaml` minimale potrebbe essere:
+
+```yaml
+debug: true
+openai:
+  stt_model: gpt-4o-mini-transcribe
+```
+
+Se ad esempio `audio.sample_rate` contiene una stringa (`"ventiquattromila"`) invece di un
+numero, Pydantic segnalerà `Input should be a valid integer` e userà `24000`.
+
+## Test
+
+Per eseguire i test installa le dipendenze e lancia `pytest`:
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/OcchioOnniveggente/requirements.txt
+++ b/OcchioOnniveggente/requirements.txt
@@ -11,3 +11,5 @@ langdetect>=1.0.9
 better-profanity>=0.7.0
 Unidecode>=1.3.8
 pydub>=0.25.1
+
+pydantic>=2

--- a/OcchioOnniveggente/src/config.py
+++ b/OcchioOnniveggente/src/config.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+from typing import Dict, List, Literal, Optional, Tuple
+
+import yaml
+from pydantic import BaseModel, Field
+
+
+class OpenAIConfig(BaseModel):
+    stt_model: str = "gpt-4o-mini-transcribe"
+    llm_model: str = "gpt-5-mini"
+    tts_model: str = "gpt-4o-mini-tts"
+    tts_voice: str = "alloy"
+
+
+class AudioConfig(BaseModel):
+    sample_rate: int = 24_000
+    ask_seconds: int = 10
+    input_wav: str = "data/temp/input.wav"
+    output_wav: str = "data/temp/answer.wav"
+    input_device: Optional[str | int] = None
+    output_device: Optional[str | int] = None
+
+
+class RecordingConfig(BaseModel):
+    mode: Literal["vad", "timed"] = "vad"
+    timed_seconds: int = 10
+    fallback_to_timed: bool = False
+    min_speech_level: float = 0.01
+
+
+class VadConfig(BaseModel):
+    frame_ms: int = 30
+    start_ms: int = 150
+    end_ms: int = 800
+    max_ms: int = 15_000
+    preroll_ms: int = 300
+    noise_window_ms: int = 800
+    start_mult: float = 1.8
+    end_mult: float = 1.3
+    base_start: float = 0.006
+    base_end: float = 0.0035
+
+
+class FilterConfig(BaseModel):
+    mode: Literal["block", "mask"] = "block"
+
+
+class SacnConfig(BaseModel):
+    universe: int = 1
+    destination_ip: str
+    rgb_channels: List[int]
+    idle_level: int = 10
+    peak_level: int = 255
+
+
+class WledConfig(BaseModel):
+    host: str
+
+
+class LightingConfig(BaseModel):
+    mode: Literal["sacn", "wled"] = "sacn"
+    sacn: SacnConfig = SacnConfig(destination_ip="192.168.1.50", rgb_channels=[1, 2, 3])
+    wled: WledConfig = WledConfig(host="192.168.1.77")
+
+
+class PaletteItem(BaseModel):
+    rgb: Tuple[int, int, int]
+    style: str
+
+
+class Settings(BaseModel):
+    debug: bool = False
+    openai: OpenAIConfig = OpenAIConfig()
+    audio: AudioConfig = AudioConfig()
+    recording: RecordingConfig = RecordingConfig()
+    vad: VadConfig = VadConfig()
+    filter: FilterConfig = FilterConfig()
+    lighting: LightingConfig = LightingConfig()
+    palette_keywords: Dict[str, PaletteItem] = Field(default_factory=dict)
+    oracle_system: str = ""
+
+    @classmethod
+    def model_validate_yaml(cls, path: Path) -> "Settings":
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        return cls.model_validate(data)

--- a/tests/data/filters/en_blacklist.txt
+++ b/tests/data/filters/en_blacklist.txt
@@ -1,0 +1,2 @@
+shit
+son of a bitch

--- a/tests/data/filters/it_blacklist.txt
+++ b/tests/data/filters/it_blacklist.txt
@@ -1,0 +1,2 @@
+cazz*
+porco dio

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import importlib.util
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "filters", Path(__file__).resolve().parents[1] / "OcchioOnniveggente" / "src" / "filters.py"
+)
+filters = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(filters)
+ProfanityFilter = filters.ProfanityFilter
+
+
+@pytest.fixture()
+def pf() -> ProfanityFilter:
+    data_dir = Path(__file__).parent / "data" / "filters"
+    return ProfanityFilter(data_dir / "it_blacklist.txt", data_dir / "en_blacklist.txt")
+
+
+def test_recognizes_leet_and_accents(pf: ProfanityFilter) -> None:
+    assert pf.contains_profanity("càzz0 che schifo")
+    assert pf.contains_profanity("sh1t happens")
+
+
+def test_mask_preserves_length(pf: ProfanityFilter) -> None:
+    text = "This is shit"
+    masked = pf.mask(text)
+    assert len(masked) == len(text)
+    assert masked != text
+
+
+def test_multiword_phrase_with_punctuation(pf: ProfanityFilter) -> None:
+    assert pf.contains_profanity("Che porco, dio?")
+    assert pf.contains_profanity("you son-of a bitch")


### PR DESCRIPTION
## Summary
- introduce typed `Settings` module with Pydantic validation and defaults
- add `debug_print_devices` helper and use validated config in `main.py`
- document configuration handling and testing instructions in README
- add profanity filter test suite with minimal blacklist data

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile src/config.py src/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a65615a8ac8327907651154f226d58