### PR TITLE
Add package initializer for src module

### DIFF
--- a/OcchioOnniveggente/src/__init__.py
+++ b/OcchioOnniveggente/src/__init__.py
@@ -1,0 +1,1 @@
+"""OcchioOnniveggente package initialization."""


### PR DESCRIPTION
## Summary
- add `__init__.py` so `src` is recognized as a package

## Testing
- `pytest -q`
- `python -m src.main` *(fails: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68a66027e63c8327a6c7af7639e6d0df