### PR TITLE
Handle missing settings file

### DIFF
--- a/OcchioOnniveggente/src/config.py
+++ b/OcchioOnniveggente/src/config.py
@@ -81,5 +81,8 @@ class Settings(BaseModel):
 
     @classmethod
     def model_validate_yaml(cls, path: Path) -> "Settings":
-        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        try:
+            data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return cls()
         return cls.model_validate(data)

--- a/OcchioOnniveggente/src/main.py
+++ b/OcchioOnniveggente/src/main.py
@@ -66,8 +66,11 @@ def main() -> None:
     load_dotenv()
     client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 
+    config_path = Path("settings.yaml")
+    if not config_path.exists():
+        print("⚠️ File di configurazione non trovato, uso impostazioni di default.")
     try:
-        SET = Settings.model_validate_yaml(Path("settings.yaml"))
+        SET = Settings.model_validate_yaml(config_path)
     except ValidationError as e:
         print("⚠️ Configurazione non valida:", e)
         print("Uso impostazioni di default.")


### PR DESCRIPTION
## Summary
- Return default Settings when settings YAML file is missing
- Log fallback to default settings when configuration file cannot be found

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a66031c90483278937cdcf02869077