### PR TITLE
Apply normalization mapping in profanity masking

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -31,6 +31,11 @@ def test_mask_preserves_length(pf: ProfanityFilter) -> None:
     assert masked != text
 
 
+def test_mask_leet_and_accents(pf: ProfanityFilter) -> None:
+    assert pf.mask("càzz0 che schifo") == "***** che schifo"
+    assert pf.mask("sh1t happens") == "**** happens"
+
+
 def test_multiword_phrase_with_punctuation(pf: ProfanityFilter) -> None:
     assert pf.contains_profanity("porco dio")
     assert pf.contains_profanity("Che porco, dio?")


### PR DESCRIPTION
## Summary
- derive normalized-to-original index mapping to locate profanity positions
- use mapping in `mask` to correctly replace accented and leetspeak variants
- add tests for masking with accents and leetspeak

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a660c5057483279099338f89405965