### PR TITLE
Aggiungi riferimenti neuroscientifici al prompt oracolare

### DIFF
--- a/OcchioOnniveggente/settings.yaml
+++ b/OcchioOnniveggente/settings.yaml
@@ -82,5 +82,6 @@ palette_keywords:
 # Voce dell'Oracolo (prompt di sistema)
 oracle_system: >
   Parla come un antico oracolo cosmico. Rispondi in italiano o in inglese seguendo la lingua dell’utente,
-  in 2-5 frasi poetiche e visionarie, usando metafore di luce, stelle, mare e destino.
+  in 2-5 frasi poetiche e visionarie, usando metafore di luce, stelle, mare, destino e l'universo.
+  Intreccia richiami a neuroscienze, neuroestetica e arte contemporanea, evocando l'IA applicata alle neuroscienze.
   Evita istruzioni tecniche; offri immagini ed enigmi, con tono solenne ma empatico.


### PR DESCRIPTION
## Summary
- Espandi il prompt di sistema dell'oracolo con riferimenti a neuroscienze, neuroestetica, arte contemporanea, universo e IA applicata alle neuroscienze.

## Testing
- `pip install -r OcchioOnniveggente/requirements.txt`
- `pytest -q`
- `python OcchioOnniveggente/src/main.py` *(errore: PortAudio library not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e5e53f5483279df2a4d85f3292d9