### PR TITLE
Gate Oracle responses by allowed topics

### DIFF
--- a/OcchioOnniveggente/src/main.py
+++ b/OcchioOnniveggente/src/main.py
@@ -11,7 +11,22 @@ from src.config import Settings
 from src.filters import ProfanityFilter
 from src.audio import record_until_silence, play_and_pulse
 from src.lights import SacnLight, WledLight, color_from_text
-from src.oracle import transcribe, oracle_answer, synthesize, append_log
+from src.oracle import (
+    transcribe,
+    oracle_answer,
+    synthesize,
+    append_log,
+    is_relevant,
+)
+
+
+TOPICS = [
+    "neuroscience",
+    "neuroaesthetics",
+    "contemporary art",
+    "universe",
+    "neuroscientific ai",
+]
 
 
 def pick_device(spec: Any, kind: str) -> Any:
@@ -151,7 +166,14 @@ def main() -> None:
                     q = PROF.mask(q)
                     print("⚠️ Testo filtrato:", q)
 
-            a = oracle_answer(q, lang or "it", client, LLM_MODEL, ORACLE_SYSTEM)
+            if not is_relevant(q, TOPICS):
+                a = (
+                    "The question is not relevant. Try asking something else."
+                    if lang == "en"
+                    else "La domanda non è pertinente. Prova a chiedere altro."
+                )
+            else:
+                a = oracle_answer(q, lang or "it", client, LLM_MODEL, ORACLE_SYSTEM)
 
             if PROF.contains_profanity(a):
                 if FILTER_MODE == "block":

--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -22,6 +22,25 @@ _EN_SW = {
 }
 
 
+def is_relevant(question: str, topics: list[str]) -> bool:
+    """Check if *question* mentions at least one of the allowed *topics*.
+
+    Matching is case-insensitive and looks for whole words/phrases to avoid
+    accidental partial hits (e.g. ``art`` in ``cartoon``).
+    """
+
+    if not question or not topics:
+        return False
+
+    for topic in topics:
+        # ``re.escape`` guards against special characters in topics; ``\b``
+        # ensures we match whole words or phrases.
+        pattern = rf"\b{re.escape(topic)}\b"
+        if re.search(pattern, question, flags=re.IGNORECASE):
+            return True
+    return False
+
+
 def _score_lang(text: str, lang: str, *, debug: bool = False) -> float:
     if not text:
         return 0.0

--- a/tests/test_oracle.py
+++ b/tests/test_oracle.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from OcchioOnniveggente.src.oracle import is_relevant
+
+
+def test_is_relevant_case_insensitive():
+    topics = ["neuroscience", "contemporary art"]
+    assert is_relevant("Tell me about NEUROSCIENCE", topics)
+    assert is_relevant("I love Contemporary Art pieces", topics)
+
+
+def test_is_relevant_no_match():
+    topics = ["neuroscience", "contemporary art"]
+    assert not is_relevant("Let's talk about cooking", topics)
+
+
+def test_is_relevant_word_boundaries():
+    assert not is_relevant("This is a smart move", ["art"])


### PR DESCRIPTION
## Summary
- add `is_relevant` helper to match questions against a list of allowed topics
- invoke relevance check in the main loop and return IT/EN fallback message when irrelevant
- cover relevance helper with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a72cfe93d0832792e053734695c8ec