### PR TITLE
Add topic filtering and rejection messages

### DIFF
--- a/OcchioOnniveggente/settings.yaml
+++ b/OcchioOnniveggente/settings.yaml
@@ -85,3 +85,14 @@ oracle_system: >
   in 2-5 frasi poetiche e visionarie, usando metafore di luce, stelle, mare, destino e l'universo.
   Intreccia richiami a neuroscienze, neuroestetica e arte contemporanea, evocando l'IA applicata alle neuroscienze.
   Evita istruzioni tecniche; offri immagini ed enigmi, con tono solenne ma empatico.
+  Rispondi solo se la domanda riguarda {allowed_topics}. Se non è pertinente, restituisci il messaggio di rifiuto.
+
+allowed_topics:
+  - neuroscienze
+  - neuroestetica
+  - arte contemporanea
+  - universo
+  - IA applicata alle neuroscienze
+
+reject_answer_it: "Mi dispiace, posso rispondere solo a domande su neuroscienze, neuroestetica, arte contemporanea, universo e IA applicata alle neuroscienze."
+reject_answer_en: "I'm sorry, I can only answer questions about neuroscience, neuroaesthetics, contemporary art, the universe, and AI applied to neuroscience."

--- a/OcchioOnniveggente/src/config.py
+++ b/OcchioOnniveggente/src/config.py
@@ -78,6 +78,23 @@ class Settings(BaseModel):
     lighting: LightingConfig = LightingConfig()
     palette_keywords: Dict[str, PaletteItem] = Field(default_factory=dict)
     oracle_system: str = ""
+    allowed_topics: List[str] = Field(
+        default_factory=lambda: [
+            "neuroscienze",
+            "neuroestetica",
+            "arte contemporanea",
+            "universo",
+            "IA applicata alle neuroscienze",
+        ]
+    )
+    reject_answer_it: str = (
+        "Mi dispiace, posso rispondere solo a domande su neuroscienze, "
+        "neuroestetica, arte contemporanea, universo e IA applicata alle neuroscienze."
+    )
+    reject_answer_en: str = (
+        "I'm sorry, I can only answer questions about neuroscience, "
+        "neuroaesthetics, contemporary art, the universe, and AI applied to neuroscience."
+    )
 
     @classmethod
     def model_validate_yaml(cls, path: Path) -> "Settings":

--- a/OcchioOnniveggente/src/main.py
+++ b/OcchioOnniveggente/src/main.py
@@ -97,6 +97,9 @@ def main() -> None:
     TTS_MODEL = SET.openai.tts_model
     TTS_VOICE = SET.openai.tts_voice
     ORACLE_SYSTEM = SET.oracle_system
+    ALLOWED_TOPICS = SET.allowed_topics
+    REJECT_IT = SET.reject_answer_it
+    REJECT_EN = SET.reject_answer_en
 
     FILTER_MODE = SET.filter.mode
     PALETTES = {k: v.model_dump() for k, v in SET.palette_keywords.items()}
@@ -141,6 +144,10 @@ def main() -> None:
             if not q:
                 continue
 
+            if not any(t.lower() in q.lower() for t in ALLOWED_TOPICS):
+                print(REJECT_EN if (lang or "it") == "en" else REJECT_IT)
+                continue
+
             if PROF.contains_profanity(q):
                 if FILTER_MODE == "block":
                     print(
@@ -151,7 +158,16 @@ def main() -> None:
                     q = PROF.mask(q)
                     print("⚠️ Testo filtrato:", q)
 
-            a = oracle_answer(q, lang or "it", client, LLM_MODEL, ORACLE_SYSTEM)
+            a = oracle_answer(
+                q,
+                lang or "it",
+                client,
+                LLM_MODEL,
+                ORACLE_SYSTEM,
+                ALLOWED_TOPICS,
+                REJECT_IT,
+                REJECT_EN,
+            )
 
             if PROF.contains_profanity(a):
                 if FILTER_MODE == "block":

--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -115,12 +115,24 @@ def transcribe(path: Path, client, stt_model: str, *, debug: bool = False) -> Tu
         return text_en, "en"
 
 
-def oracle_answer(question: str, lang_hint: str, client, llm_model: str, oracle_system: str) -> str:
+def oracle_answer(
+    question: str,
+    lang_hint: str,
+    client,
+    llm_model: str,
+    oracle_system: str,
+    allowed_topics: list[str],
+    reject_answer_it: str,
+    reject_answer_en: str,
+) -> str:
     print("✨ Interrogo l’Oracolo…")
     lang_clause = "Answer in English." if lang_hint == "en" else "Rispondi in italiano."
+    reject = reject_answer_en if lang_hint == "en" else reject_answer_it
+    instructions = oracle_system.format(allowed_topics=", ".join(allowed_topics))
+    instructions += f" Il messaggio di rifiuto è: {reject}"
     resp = client.responses.create(
         model=llm_model,
-        instructions=(oracle_system + " " + lang_clause),
+        instructions=(instructions + " " + lang_clause),
         input=[{"role": "user", "content": question}],
     )
     ans = resp.output_text.strip()


### PR DESCRIPTION
## Summary
- extend Settings with allowed topics and rejection messages
- add new configuration fields and prompt instructions
- filter questions by topic and propagate rejection message

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a72d0047688327938b327259bedbd5