### PR TITLE
Add relevance utility and tests

### DIFF
--- a/OcchioOnniveggente/src/ai/__init__.py
+++ b/OcchioOnniveggente/src/ai/__init__.py
@@ -1,0 +1,10 @@
+from typing import Iterable, Tuple
+
+
+def is_relevant(question: str, allowed_topics: Iterable[str], refusal_message: str) -> Tuple[bool, str]:
+    """Return True if question contains any allowed topic, else False and refusal message."""
+    lowered = question.lower()
+    for topic in allowed_topics:
+        if topic.lower() in lowered:
+            return True, ""
+    return False, refusal_message

--- a/tests/test_relevance.py
+++ b/tests/test_relevance.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from OcchioOnniveggente.src.ai import is_relevant
+
+
+@pytest.fixture()
+def allowed_topics() -> list[str]:
+    return ["pizza", "musica"]
+
+
+@pytest.fixture()
+def refusal_message() -> str:
+    return "Domanda fuori tema"
+
+
+def test_question_with_topic(allowed_topics, refusal_message) -> None:
+    result, message = is_relevant("Parlami della pizza", allowed_topics, refusal_message)
+    assert result is True
+    assert message == ""
+
+
+def test_question_without_topic(allowed_topics, refusal_message) -> None:
+    result, message = is_relevant("Che tempo fa oggi?", allowed_topics, refusal_message)
+    assert result is False
+    assert message == refusal_message


### PR DESCRIPTION
## Summary
- implement `is_relevant` helper to check whether questions mention allowed topics
- add tests validating topic detection and refusal message behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a72d03432883279ce8ca8a4b0e45a1