### PR TITLE
docs: explain allowed topics and refusal messages

### DIFF
--- a/OcchioOnniveggente/settings.yaml
+++ b/OcchioOnniveggente/settings.yaml
@@ -58,6 +58,17 @@ vad:
 filter:
   mode: block
 
+# Argomenti consentiti per le domande. Modifica la lista per cambiare i temi ammessi.
+allowed_topics:
+  - arte
+  - scienza
+  - filosofia
+
+# Messaggi restituiti quando la domanda non rientra negli argomenti consentiti.
+# Aggiungi o modifica le frasi secondo le tue esigenze.
+refusal_messages:
+  - "Non posso parlare di questo. Chiedimi di arte, scienza o filosofia."
+
 # Luci: sACN/E1.31 o WLED
 lighting:
   mode: "sacn"            # "sacn" oppure "wled"

--- a/README.md
+++ b/README.md
@@ -25,3 +25,15 @@ python -m src.ui
 L'interfaccia offre un menu **Impostazioni** per scegliere i dispositivi audio
 e modificare i parametri di illuminazione (Art-Net/sACN o WLED).
 
+## Domande pertinenti
+
+L'Oracolo risponde soltanto a domande sui temi ammessi:
+**arte**, **scienza** e **filosofia**. Se la richiesta non rientra in questi
+argomenti, il sistema risponde con un messaggio di rifiuto, ad esempio:
+"Non posso parlare di questo. Chiedimi di arte, scienza o filosofia.".
+
+Per aggiungere o rimuovere argomenti consentiti modifica la lista
+`allowed_topics` in `OcchioOnniveggente/settings.yaml`. Nello stesso file puoi
+personalizzare i messaggi di rifiuto modificando la sezione
+`refusal_messages`.
+


### PR DESCRIPTION
## Summary
- document allowed topics and default refusal response
- add configurable `allowed_topics` and `refusal_messages` in settings.yaml

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a72d05d9a88327bfae6ec81e63c477