### PR TITLE
feat: add document ingestion script

### DIFF
--- a/OcchioOnniveggente/scripts/ingest_docs.py
+++ b/OcchioOnniveggente/scripts/ingest_docs.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import argparse
+import importlib
+import logging
+from pathlib import Path
+from typing import Iterable, List
+
+logging.basicConfig(level=logging.INFO)
+
+
+def _gather_files(paths: Iterable[str]) -> List[Path]:
+    files: List[Path] = []
+    for raw in paths:
+        path = Path(raw)
+        if path.is_dir():
+            for file in path.rglob("*"):
+                if file.is_file():
+                    files.append(file)
+        elif path.is_file():
+            files.append(path)
+        else:
+            logging.warning("Skipping unknown path %s", path)
+    return files
+
+
+def _load_db():
+    module = importlib.import_module("documentdb")
+    DocumentDB = getattr(module, "DocumentDB")
+    return DocumentDB()
+
+
+def _add(paths: Iterable[str]) -> None:
+    db = _load_db()
+    files = _gather_files(paths)
+    documents = []
+    for file in files:
+        try:
+            documents.append({"id": str(file), "text": file.read_text(encoding="utf-8")})
+        except Exception as exc:  # pragma: no cover - logging only
+            logging.error("Failed to read %s: %s", file, exc)
+    if documents:
+        db.add_documents(documents)
+    logging.info("Indexed %d documents", len(documents))
+
+
+def _remove(paths: Iterable[str]) -> None:
+    db = _load_db()
+    files = _gather_files(paths)
+    ids = [str(file) for file in files]
+    if hasattr(db, "delete_documents"):
+        db.delete_documents(ids)
+    elif hasattr(db, "remove_documents"):
+        db.remove_documents(ids)
+    else:  # pragma: no cover - defensive branch
+        raise AttributeError("DocumentDB does not support removing documents")
+    logging.info("Removed %d documents", len(ids))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Ingest or remove documents")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--add", nargs="+", help="Paths of files or directories to index")
+    group.add_argument("--remove", nargs="+", help="Paths of files or directories to remove")
+    args = parser.parse_args()
+
+    if args.add:
+        _add(args.add)
+    elif args.remove:
+        _remove(args.remove)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script to ingest documents via DocumentDB and remove them with CLI
- support folders or individual files and log indexed count

## Testing
- `pytest`
- `ruff check`
- `pyright` *(fails: DocumentDB not found or other errors? Wait but error is due to existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68a7310ca1008327a7f256eee34ffc9d