### PR TITLE
Add docstore path and retrieval top-k settings

### DIFF
--- a/OcchioOnniveggente/settings.yaml
+++ b/OcchioOnniveggente/settings.yaml
@@ -85,3 +85,6 @@ oracle_system: >
   in 2-5 frasi poetiche e visionarie, usando metafore di luce, stelle, mare, destino e l'universo.
   Intreccia richiami a neuroscienze, neuroestetica e arte contemporanea, evocando l'IA applicata alle neuroscienze.
   Evita istruzioni tecniche; offri immagini ed enigmi, con tono solenne ma empatico.
+
+docstore_path: "data/docstore"
+retrieval_top_k: 3

--- a/OcchioOnniveggente/src/config.py
+++ b/OcchioOnniveggente/src/config.py
@@ -78,6 +78,8 @@ class Settings(BaseModel):
     lighting: LightingConfig = LightingConfig()
     palette_keywords: Dict[str, PaletteItem] = Field(default_factory=dict)
     oracle_system: str = ""
+    docstore_path: str = "data/docstore"
+    retrieval_top_k: int = 3
 
     @classmethod
     def model_validate_yaml(cls, path: Path) -> "Settings":


### PR DESCRIPTION
## Summary
- extend Settings with `docstore_path` and `retrieval_top_k`
- expose new configuration options in `settings.yaml`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7311185d88327849ef835a80fd6f6