### PR TITLE
feat: configure document database

### DIFF
--- a/OcchioOnniveggente/README.md
+++ b/OcchioOnniveggente/README.md
@@ -33,6 +33,26 @@ openai:
 Se ad esempio `audio.sample_rate` contiene una stringa (`"ventiquattromila"`) invece di un
 numero, Pydantic segnalerà `Input should be a valid integer` e userà `24000`.
 
+## DataBase dei documenti
+
+I testi consultati dall'Oracolo vanno inseriti nella cartella `DataBase/` alla radice del
+progetto. Dopo aver aggiunto o rimosso file, esegui lo script di ingestione per
+rigenerare l'indice:
+
+```bash
+python scripts/ingest_docs.py --add DataBase/nuovo_file.txt
+python scripts/ingest_docs.py --remove DataBase/vecchio_file.txt
+```
+
+Puoi anche indicizzare l'intera cartella in un'unica volta:
+
+```bash
+python scripts/ingest_docs.py --add DataBase
+```
+
+Rieseguendo lo script dopo ogni modifica l'indice viene aggiornato con i contenuti
+presenti in `DataBase/`.
+
 ## Test
 
 Per eseguire i test installa le dipendenze e lancia `pytest`:

--- a/OcchioOnniveggente/settings.yaml
+++ b/OcchioOnniveggente/settings.yaml
@@ -86,5 +86,5 @@ oracle_system: >
   Intreccia richiami a neuroscienze, neuroestetica e arte contemporanea, evocando l'IA applicata alle neuroscienze.
   Evita istruzioni tecniche; offri immagini ed enigmi, con tono solenne ma empatico.
 
-docstore_path: "data/docstore"
+docstore_path: "DataBase"
 retrieval_top_k: 3


### PR DESCRIPTION
## Summary
- add `DataBase` directory and use it as default docstore path
- let `ingest_docs.py` read the docstore path from `settings.yaml`
- document how to manage files in the `DataBase` and regenerate the index

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7368bfbf483279c783fb868435d51