### PR TITLE
docs: add document management section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,13 @@ python -m src.ui
 L'interfaccia offre un menu **Impostazioni** per scegliere i dispositivi audio
 e modificare i parametri di illuminazione (Art-Net/sACN o WLED).
 
+## Gestione documenti
+
+Il menu **Documenti** consente di inserire o rimuovere file dal datastore.
+Dopo ogni modifica utilizzare il pulsante **Aggiorna indice** per rigenerare
+l'indice di ricerca.
+
+I documenti vengono salvati nella cartella predefinita `DataBase`. È possibile
+personalizzare il percorso modificando il parametro `docstore_path` in
+`OcchioOnniveggente/settings.yaml`.
+


### PR DESCRIPTION
## Summary
- document how to add/remove files via the **Documenti** menu
- explain the **Aggiorna indice** button
- mention default `DataBase` path and customization via `settings.yaml`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a73d2d06f8832783588c599fa1e319