### PR TITLE
Graceful handling of audio device errors

### DIFF
--- a/OcchioOnniveggente/src/main.py
+++ b/OcchioOnniveggente/src/main.py
@@ -190,7 +190,8 @@ def main() -> None:
                 input_device_id=in_dev,
             )
             if not ok:
-                # nessun parlato: in UI restiamo dormienti
+                print("⚠️ Registrazione audio non riuscita, riprovo tra 2s…", flush=True)
+                time.sleep(2)
                 continue
 
             # 2) Trascrizione + lingua


### PR DESCRIPTION
## Summary
- Handle missing audio devices by wrapping `sd.InputStream` and `sd.play` in `PortAudioError` handlers
- Return `False` on microphone errors and continue gracefully on playback errors
- Retry audio capture with a delay when recording fails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a75e0f24f8832788c84fa672fc38ee