### PR TITLE
Handle unknown args in ingestion script

### DIFF
--- a/OcchioOnniveggente/README.md
+++ b/OcchioOnniveggente/README.md
@@ -53,6 +53,10 @@ python scripts/ingest_docs.py --add DataBase
 Rieseguendo lo script dopo ogni modifica l'indice viene aggiornato con i contenuti
 presenti in `DataBase/`.
 
+Lo script supporta soltanto le opzioni `--add` e `--remove`; eventuali
+argomenti supplementari (ad esempio `--model-dir` o `--video_dir`), eventualmente
+passati da interfacce o wrapper legacy, vengono semplicemente ignorati.
+
 ## Test
 
 Per eseguire i test installa le dipendenze e lancia `pytest`:

--- a/OcchioOnniveggente/scripts/ingest_docs.py
+++ b/OcchioOnniveggente/scripts/ingest_docs.py
@@ -75,7 +75,10 @@ def main() -> None:
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--add", nargs="+", help="Paths of files or directories to index")
     group.add_argument("--remove", nargs="+", help="Paths of files or directories to remove")
-    args = parser.parse_args()
+    # Tolleranza verso argomenti extra (es. UI legacy che passa --model-dir o simili)
+    args, unknown = parser.parse_known_args()
+    if unknown:
+        logging.warning("Ignoring unknown arguments: %s", " ".join(unknown))
 
     if args.add:
         _add(args.add, args.path)


### PR DESCRIPTION
## Summary
- tolerate extra CLI flags in `scripts/ingest_docs.py`
- document supported options in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a76e0e2f748327aee53594bcc95922