### PR TITLE
Add configurable wakeword detection

### DIFF
--- a/OcchioOnniveggente/settings.yaml
+++ b/OcchioOnniveggente/settings.yaml
@@ -2,6 +2,7 @@
 
 # Log di debug (mostra device audio e info VAD)
 debug: false
+wakeword: "porcupine"
 
 openai:
   # Modello per trascrizione audio (puoi usare anche "whisper-1")

--- a/OcchioOnniveggente/src/config.py
+++ b/OcchioOnniveggente/src/config.py
@@ -70,6 +70,7 @@ class PaletteItem(BaseModel):
 
 class Settings(BaseModel):
     debug: bool = False
+    wakeword: Optional[str] = None
     openai: OpenAIConfig = OpenAIConfig()
     audio: AudioConfig = AudioConfig()
     recording: RecordingConfig = RecordingConfig()

--- a/OcchioOnniveggente/src/hotword.py
+++ b/OcchioOnniveggente/src/hotword.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Utilities for hotword detection.
+
+This module provides a helper function :func:`listen_for_wakeword` that blocks
+until a configured wake word is detected using a wake word engine such as
+Porcupine or Snowboy.  If the required third party dependencies are not
+available, the function falls back to a no-op so that the application can still
+run without hotword support.
+"""
+
+from typing import Optional
+
+
+def listen_for_wakeword(wakeword: str, device_id: Optional[int] = None) -> None:
+    """Block until *wakeword* is detected on the microphone.
+
+    Parameters
+    ----------
+    wakeword:
+        Name of the keyword model to detect.  This should match one of the
+        keywords supported by the underlying engine (e.g. "picovoice",
+        "porcupine", ...).
+    device_id:
+        Optional index of the input device to use.  ``None`` lets the backend
+        choose the default system device.
+
+    Notes
+    -----
+    The function attempts to use `pvporcupine` (Picovoice Porcupine) for
+    detection.  If the dependency or ``pyaudio`` is missing, a warning is
+    printed and the function returns immediately without waiting.
+    """
+
+    try:
+        import struct
+        import pvporcupine
+        import pyaudio
+    except Exception:
+        # Hotword detection is optional; gracefully skip if dependencies
+        # are not available in the runtime environment.
+        print("⚠️ Wakeword engine not available, continuing without hotword.", flush=True)
+        return
+
+    porcupine = pvporcupine.create(keywords=[wakeword])
+    pa = pyaudio.PyAudio()
+    stream = pa.open(
+        rate=porcupine.sample_rate,
+        channels=1,
+        format=pyaudio.paInt16,
+        input=True,
+        frames_per_buffer=porcupine.frame_length,
+        input_device_index=device_id,
+    )
+
+    try:
+        while True:
+            pcm = stream.read(porcupine.frame_length, exception_on_overflow=False)
+            pcm = struct.unpack_from("h" * porcupine.frame_length, pcm)
+            if porcupine.process(pcm) >= 0:
+                break
+    finally:
+        stream.stop_stream()
+        stream.close()
+        pa.terminate()
+        porcupine.delete()


### PR DESCRIPTION
## Summary
- add Porcupine-based hotword detection helper
- call hotword listener before recording in main loop
- expose optional `wakeword` setting saved in settings.yaml

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a77abc63cc8327a2673cebc486cf36