### PR TITLE
feat: send handshake for realtime websocket

### DIFF
--- a/OcchioOnniveggente/src/realtime_oracolo.py
+++ b/OcchioOnniveggente/src/realtime_oracolo.py
@@ -104,6 +104,12 @@ async def main(url: str = WS_URL, sr: int = SR) -> None:
     state: dict[str, Any] = {"tts_playing": False, "barge_sent": False}
 
     async with websockets.connect(url) as ws:
+        # Invio di un messaggio iniziale di "hello" con il sample rate
+        # previsto dal client. Il server si aspetta questo handshake prima
+        # di ricevere qualsiasi frame audio; senza di esso la connessione
+        # viene chiusa immediatamente.
+        await ws.send(json.dumps({"sr": sr}))
+
         tasks = [
             asyncio.create_task(_mic_worker(ws, send_q, sr=sr, state=state)),
             asyncio.create_task(_sender(ws, send_q)),

--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -204,6 +204,11 @@ class RealtimeWSClient:
         self.stop_event = asyncio.Event()
         async with websockets.connect(self.url) as ws:
             self.ws = ws
+            print(
+                f"🔌 Realtime WS → {self.url}  (sr={self.sr}, in={sd.default.device[0]}, out={sd.default.device[1]})",
+                flush=True,
+            )
+            await ws.send(json.dumps({"sr": self.sr}))
             tasks = [
                 asyncio.create_task(self._mic_worker()),
                 asyncio.create_task(self._sender()),


### PR DESCRIPTION
## Summary
- send initial handshake from realtime client with sample rate before streaming audio
- ensure UI-based realtime client sends handshake and logs connection details

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a83f387af083278f5aeab6f32cb7b7