### PR TITLE
Enable multi-turn chat with persistent state and UI controls

### DIFF
--- a/OcchioOnniveggente/settings.yaml
+++ b/OcchioOnniveggente/settings.yaml
@@ -138,6 +138,13 @@ realtime:
   ping_interval: 20              # opzionale, se il server richiede ping WS
   ping_timeout: 20
 
+# Stato conversazione (chat multi-turno)
+chat:
+  enabled: true
+  max_turns: 10
+  reset_on_hotword: true
+  persist_jsonl: data/logs/chat_sessions.jsonl
+
 # RAG: dove sono i documenti indicizzati e quanti frammenti prendere
 docstore_path: DataBase/index.json
 retrieval_top_k: 3

--- a/OcchioOnniveggente/src/chat.py
+++ b/OcchioOnniveggente/src/chat.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Dict, Optional
+import time, json
+
+
+@dataclass
+class ChatState:
+    max_turns: int = 10
+    persist_jsonl: Optional[Path] = None
+    session_id: str = str(int(time.time()))
+    history: List[Dict[str, str]] = field(default_factory=list)
+
+    def reset(self) -> None:
+        self.history.clear()
+
+    def push_user(self, text: str) -> None:
+        self.history.append({"role": "user", "content": text})
+        self._trim()
+        self._persist("user", text)
+
+    def push_assistant(self, text: str) -> None:
+        self.history.append({"role": "assistant", "content": text})
+        self._trim()
+        self._persist("assistant", text)
+
+    def _trim(self) -> None:
+        if self.max_turns > 0:
+            excess = len(self.history) - (2 * self.max_turns)
+            if excess > 0:
+                self.history = self.history[excess:]
+
+    def _persist(self, role: str, text: str) -> None:
+        if not self.persist_jsonl:
+            return
+        rec = {
+            "ts": int(time.time()),
+            "session_id": self.session_id,
+            "role": role,
+            "text": text,
+        }
+        self.persist_jsonl.parent.mkdir(parents=True, exist_ok=True)
+        with self.persist_jsonl.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(rec, ensure_ascii=False) + "\n")

--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -116,19 +116,18 @@ def oracle_answer(
     oracle_system: str,
     *,
     context: list[dict] | None = None,
-    history: list[tuple[str, str]] | None = None,
+    history: list[dict[str, str]] | None = None,
 ) -> str:
     print("✨ Interrogo l’Oracolo…")
     lang_clause = "Answer in English." if lang_hint == "en" else "Rispondi in italiano."
 
-    messages = []
+    messages: list[dict[str, str]] = []
     if context:
         ctx_txt = "\n\n".join(str(c.get("text", "")) for c in context if c.get("text"))
         if ctx_txt:
             messages.append({"role": "system", "content": f"Contesto:\n{ctx_txt}"})
-    for q_prev, a_prev in (history or []):
-        messages.append({"role": "user", "content": q_prev})
-        messages.append({"role": "assistant", "content": a_prev})
+    if history:
+        messages.extend(history)
     messages.append({"role": "user", "content": question})
 
     sys_prompt = (


### PR DESCRIPTION
## Summary
- Add `ChatState` module to manage conversational history and optional JSONL persistence
- Wire chat history into core oracle flow, realtime server and Tk UI with reset support
- Expose chat configuration in settings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9c4d12dac83278392ac81f3822ae3