### PR TITLE
feat: manage multi-turn dialogue state

### DIFF
--- a/OcchioOnniveggente/src/dialogue.py
+++ b/OcchioOnniveggente/src/dialogue.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from enum import Enum, auto
+
+
+class DialogState(Enum):
+    """Possible states for the dialogue state machine."""
+
+    SLEEP = auto()
+    AWAKE = auto()
+    LISTENING = auto()
+    THINKING = auto()
+    SPEAKING = auto()
+
+
+@dataclass
+class DialogueManager:
+    """Maintain conversation state and timeouts."""
+
+    idle_timeout: float
+    state: DialogState = DialogState.SLEEP
+    active_deadline: float = 0.0
+    is_processing: bool = False
+    turn_id: int = 0
+
+    def refresh_deadline(self) -> None:
+        """Refresh the activity deadline."""
+        self.active_deadline = time.time() + self.idle_timeout
+
+    def transition(self, new_state: DialogState) -> None:
+        """Transition to a new state and refresh deadline when appropriate."""
+        self.state = new_state
+        if new_state in (DialogState.AWAKE, DialogState.LISTENING, DialogState.SPEAKING):
+            self.refresh_deadline()
+
+    def start_processing(self) -> int:
+        """Mark that a user turn is being processed and return turn id."""
+        self.is_processing = True
+        self.turn_id += 1
+        return self.turn_id
+
+    def end_processing(self) -> None:
+        """Clear processing flag after finishing the turn."""
+        self.is_processing = False
+
+    def timed_out(self, now: float) -> bool:
+        """Return True if current session expired due to inactivity."""
+        return self.state is not DialogState.SLEEP and now > self.active_deadline

--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -115,6 +115,7 @@ class RealtimeWSClient:
     def __init__(self, url: str, sr: int, on_partial, on_answer) -> None:
         self.url = url
         self.sr = sr
+        self.frame_samples = int(self.sr * 0.02)
         self.on_partial = on_partial
         self.on_answer = on_answer
         self.send_q: "queue.Queue[bytes]" = queue.Queue()
@@ -141,7 +142,13 @@ class RealtimeWSClient:
                         self.ws.send(json.dumps({"type": "barge_in"})), loop
                     )
 
-        with sd.RawInputStream(samplerate=self.sr, channels=1, dtype="int16", callback=callback):
+        with sd.RawInputStream(
+            samplerate=self.sr,
+            blocksize=self.frame_samples,
+            channels=1,
+            dtype="int16",
+            callback=callback,
+        ):
             while not self.stop_event.is_set():
                 await asyncio.sleep(0.1)
 
@@ -187,7 +194,13 @@ class RealtimeWSClient:
                 self.state["tts_playing"] = False
                 self.state["barge_sent"] = False
 
-        with sd.RawOutputStream(samplerate=self.sr, channels=1, dtype="int16", callback=callback):
+        with sd.RawOutputStream(
+            samplerate=self.sr,
+            blocksize=self.frame_samples,
+            channels=1,
+            dtype="int16",
+            callback=callback,
+        ):
             while not self.stop_event.is_set():
                 await asyncio.sleep(0.1)
 
@@ -301,6 +314,16 @@ class OracoloUI(tk.Tk):
         # settings
         self.base_settings, self.local_settings, self.settings = load_settings_pair(self.root_dir)
 
+        # quick toggles state
+        self.lang_map = {"Auto": "auto", "IT": "it", "EN": "en"}
+        self.mode_map = {"Dettagliata": "detailed", "Concisa": "concise"}
+        self.lang_choice = tk.StringVar(value="Auto")
+        default_mode = (
+            "Dettagliata" if self.settings.get("answer_mode", "detailed") == "detailed" else "Concisa"
+        )
+        self.mode_choice = tk.StringVar(value=default_mode)
+        self.style_var = tk.BooleanVar(value=True)
+
         # process & logs
         self.proc: subprocess.Popen | None = None
         self._reader_thread: threading.Thread | None = None
@@ -362,6 +385,16 @@ class OracoloUI(tk.Tk):
 
         self.status_var = tk.StringVar(value="🟡 In attesa")
         ttk.Label(bar, textvariable=self.status_var).pack(side="right")
+
+        opts = ttk.Frame(self)
+        opts.pack(fill="x", padx=16, pady=(0, 8))
+        ttk.Checkbutton(opts, text="Stile poetico", variable=self.style_var).pack(side="left")
+        ttk.Label(opts, text="Lingua:").pack(side="left", padx=(8, 4))
+        self.lang_cb = ttk.Combobox(opts, textvariable=self.lang_choice, values=list(self.lang_map.keys()), state="readonly", width=7)
+        self.lang_cb.pack(side="left")
+        ttk.Label(opts, text="Risposta:").pack(side="left", padx=(8, 4))
+        self.mode_cb = ttk.Combobox(opts, textvariable=self.mode_choice, values=list(self.mode_map.keys()), state="readonly", width=11)
+        self.mode_cb.pack(side="left")
 
         log_frame = ttk.Frame(self)
         log_frame.pack(fill="both", expand=True, padx=16, pady=(0, 12))
@@ -740,6 +773,11 @@ class OracoloUI(tk.Tk):
             env["PYTHONUNBUFFERED"] = "1"
             env["PYTHONIOENCODING"] = "utf-8"
             env["PYTHONUTF8"] = "1"
+
+            env["ORACOLO_STYLE"] = "poetic" if self.style_var.get() else "plain"
+            env["ORACOLO_LANG"] = self.lang_map.get(self.lang_choice.get(), "auto")
+            env["ORACOLO_ANSWER_MODE"] = self.mode_map.get(self.mode_choice.get(), "detailed")
+            self.settings["answer_mode"] = env["ORACOLO_ANSWER_MODE"]
 
             use_quiet = not bool(self.settings.get("debug", False))
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from OcchioOnniveggente.src.oracle import append_log, reset_last_answer_hash
+
+
+def test_append_log_writes_metadata(tmp_path: Path):
+    log = tmp_path / "log.csv"
+    reset_last_answer_hash()
+    append_log(
+        "q",
+        "a",
+        log,
+        lang="it",
+        topic="neuro",
+        sources=[{"id": "doc1", "score": 0.9}],
+    )
+    data = log.read_text(encoding="utf-8").strip().splitlines()
+    assert data[0] == '"timestamp","lang","topic","question","answer","sources"'
+    assert "doc1:0.90" in data[1]
+
+
+def test_append_log_deduplicates(tmp_path: Path):
+    log = tmp_path / "log.csv"
+    reset_last_answer_hash()
+    append_log("q1", "same", log)
+    append_log("q1", "same", log)
+    data = log.read_text(encoding="utf-8").strip().splitlines()
+    assert len(data) == 2  # header + single entry
+
+
+def test_append_log_scrubs_pii(tmp_path: Path):
+    log = tmp_path / "log.csv"
+    reset_last_answer_hash()
+    append_log(
+        "contact me at foo@example.com or 123-456-7890",
+        "ans",
+        log,
+    )
+    line = log.read_text(encoding="utf-8").strip().splitlines()[1]
+    assert "[email]" in line and "[phone]" in line

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -1,0 +1,26 @@
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from OcchioOnniveggente.src.oracle import oracle_answer
+
+
+class DummyClient:
+    def __init__(self):
+        self.last_instructions = ""
+        class Responses:
+            def __init__(self, outer):
+                self.outer = outer
+            def create(self, model, instructions, input):
+                self.outer.last_instructions = instructions
+                return SimpleNamespace(output_text="ok")
+        self.responses = Responses(self)
+
+
+def test_oracle_answer_mode_clauses():
+    c = DummyClient()
+    oracle_answer("q", "it", c, "gpt", "", policy_prompt="", mode="concise")
+    assert "Stile conciso" in c.last_instructions
+    oracle_answer("q", "it", c, "gpt", "", policy_prompt="", mode="detailed")
+    assert "Struttura: 1)" in c.last_instructions

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,0 +1,27 @@
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from OcchioOnniveggente.src.oracle import oracle_answer
+
+
+class DummyClient:
+    def __init__(self):
+        self.last_input = None
+        class Responses:
+            def __init__(self, outer):
+                self.outer = outer
+            def create(self, model, instructions, input):
+                self.outer.last_input = input
+                return SimpleNamespace(output_text="ok")
+        self.responses = Responses(self)
+
+
+def test_oracle_answer_includes_sources():
+    c = DummyClient()
+    ctx = [{"text": "alpha", "id": "a1"}]
+    oracle_answer("q", "it", c, "gpt", "", context=ctx)
+    sys_msgs = [m for m in c.last_input if m["role"] == "system"]
+    src_msg = [m for m in sys_msgs if m["content"].startswith("Fonti:")][0]
+    assert "[1] alpha" in src_msg["content"]

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -1,0 +1,59 @@
+import json
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+import numpy as np
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from OcchioOnniveggente.src.chat import ChatState
+from OcchioOnniveggente.src.retrieval import retrieve
+
+
+class DummyEmbClient:
+    def __init__(self, mapping):
+        class Embeddings:
+            def __init__(self, mapping):
+                self.mapping = mapping
+            def create(self, model, input):
+                data = []
+                for text in input:
+                    vec = self.mapping[text]
+                    data.append(SimpleNamespace(embedding=vec))
+                return SimpleNamespace(data=data)
+        self.embeddings = Embeddings(mapping)
+
+
+def test_update_topic_detects_change():
+    mapping = {
+        "tema1": np.array([1.0, 0.0], dtype=np.float32),
+        "tema1 follow": np.array([1.0, 0.1], dtype=np.float32),
+        "tema2": np.array([0.0, 1.0], dtype=np.float32),
+    }
+    client = DummyEmbClient(mapping)
+    chat = ChatState()
+
+    assert chat.update_topic("tema1", client, "m") is False
+    assert chat.update_topic("tema1 follow", client, "m") is False
+    assert chat.update_topic("tema2", client, "m") is True
+    assert chat.topic_text == "tema2"
+
+
+def test_retrieve_filters_by_topic(tmp_path: Path):
+    index = tmp_path / "index.json"
+    index.write_text(
+        '{"documents": ['
+        '{"id": "a", "text": "common cat", "topic": "t1"},'
+        '{"id": "b", "text": "common dog", "topic": "t2"}]}'
+    ,
+        encoding="utf-8",
+    )
+
+    res = retrieve("common", index, top_k=5, topic="t1")
+    assert res and all(d.get("topic") == "t1" for d in res)
+    ids = {d["id"] for d in res}
+    assert ids == {"a"}
+
+    res_all = retrieve("common", index, top_k=5)
+    ids_all = {d["id"] for d in res_all}
+    assert ids_all == {"a", "b"}
+


### PR DESCRIPTION
## Summary
- add DialogueManager with explicit dialogue states and timeout tracking
- integrate manager into main loop with turn debouncing and soft barge-in
- support topic-aware retrieval with document topic metadata and prompt guardrails
- provide GUI toggles for poetic style, language preference and answer mode
- honor these options in the main process via environment overrides
- log question metadata and citations, and enforce 20 ms audio framing
- scrub PII and deduplicate logged answers for safer audit trails

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa03dcc7a483279fc53c38b147b91e