### PR TITLE
feat: add basic chat tab with markdown and command support

### DIFF
--- a/OcchioOnniveggente/requirements.txt
+++ b/OcchioOnniveggente/requirements.txt
@@ -12,3 +12,4 @@ better-profanity>=0.7.0
 Unidecode>=1.3.8
 pydub>=0.25.1
 pydantic>=2
+markdown2>=2.4.12


### PR DESCRIPTION
## Summary
- add chat tab with markdown rendering and input bindings
- support slash commands and realtime status bar in UI
- include markdown2 dependency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa22c8444c8327a89ee21348a1fc0a