### PR TITLE
feat: add domain control panel and library view

### DIFF
--- a/OcchioOnniveggente/settings.yaml
+++ b/OcchioOnniveggente/settings.yaml
@@ -112,6 +112,7 @@ wake:
 domain:
   # Lista parole-chiave del tuo dominio (usate per keyword-overlap)
   enabled: true
+  topic: ""
   keywords:
     - neuroscienze
     - neuroestetica
@@ -130,6 +131,7 @@ domain:
     rag: 0.3
   accept_threshold: 0.5      # soglia per accettare la domanda
   clarify_margin: 0.15       # margine per chiedere chiarimenti
+  always_accept_wake: true   # accetta sempre saluti/hotword
   emb_min_sim: 0.22          # soglia minima di similarità coseno (0..1)
 
 # ⬇️ NUOVO: parametri per client Realtime/WebSocket (usati da realtime_oracolo.py / UI)


### PR DESCRIPTION
## Summary
- extend domain settings with topic field and wake-word override
- add Argomenti & Regole panel to adjust domain/RAG weights and thresholds
- introduce document library view with collection creation and index test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa2656635c8327861bc4d648a719a4