### PR TITLE
feat: add profiles and wake settings

### DIFF
--- a/OcchioOnniveggente/settings.yaml
+++ b/OcchioOnniveggente/settings.yaml
@@ -156,3 +156,44 @@ chat:
 docstore_path: DataBase/index.json
 retrieval_top_k: 3
 
+profiles:
+  Museo:
+    oracle_system: >
+      Sei l'oracolo del museo, guida i visitatori tra le opere con tono
+      ispirato e conoscenza storica.
+    domain:
+      topic: "museo"
+      keywords: ["arte", "collezione"]
+      weights: {kw: 0.4, emb: 0.3, rag: 0.3}
+    docstore_path: DataBase/museo.json
+    chat_memory: data/logs/chat_museo.jsonl
+  Conferenza:
+    oracle_system: >
+      Sei l'oracolo della conferenza, rispondi come moderatore erudito.
+    domain:
+      topic: "conferenza"
+      keywords: ["relatore", "pubblico"]
+      weights: {kw: 0.4, emb: 0.3, rag: 0.3}
+    docstore_path: DataBase/conferenza.json
+    chat_memory: data/logs/chat_conferenza.jsonl
+  Galleria:
+    oracle_system: >
+      Sei l'oracolo della galleria, descrivi le esposizioni con stile
+      evocativo.
+    domain:
+      topic: "galleria"
+      keywords: ["opera", "esposizione"]
+      weights: {kw: 0.4, emb: 0.3, rag: 0.3}
+    docstore_path: DataBase/galleria.json
+    chat_memory: data/logs/chat_galleria.jsonl
+  Didattica:
+    oracle_system: >
+      Sei l'oracolo della didattica, parla agli studenti con chiarezza e
+      stimola la curiosità.
+    domain:
+      topic: "didattica"
+      keywords: ["lezione", "studenti"]
+      weights: {kw: 0.4, emb: 0.3, rag: 0.3}
+    docstore_path: DataBase/didattica.json
+    chat_memory: data/logs/chat_didattica.jsonl
+

--- a/OcchioOnniveggente/src/chat.py
+++ b/OcchioOnniveggente/src/chat.py
@@ -14,6 +14,7 @@ class ChatState:
     history: List[Dict[str, str]] = field(default_factory=list)
     topic_emb: Optional[np.ndarray] = field(default=None, repr=False)
     topic_text: Optional[str] = None
+    pinned: List[str] = field(default_factory=list)
 
     def reset(self) -> None:
         self.history.clear()
@@ -27,6 +28,18 @@ class ChatState:
         self.history.append({"role": "assistant", "content": text})
         self._trim()
         self._persist("assistant", text)
+
+    def pin_message(self, text: str) -> None:
+        if not text:
+            return
+        self.pinned.append(text)
+        self._persist("pinned", text)
+
+    def pin_last_user(self) -> None:
+        for msg in reversed(self.history):
+            if msg.get("role") == "user":
+                self.pin_message(msg.get("content", ""))
+                break
 
     def _trim(self) -> None:
         if self.max_turns > 0:


### PR DESCRIPTION
## Summary
- add profile support with system prompts, domain presets, and memory paths
- allow pinning chat messages and adjustable turn memory
- expose wake word and idle timeout configuration with dormancy notice

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa28ce6bf88327a5045adf27b92d09