### PR TITLE
Add export and collaboration utilities

### DIFF
--- a/OcchioOnniveggente/src/chat.py
+++ b/OcchioOnniveggente/src/chat.py
@@ -60,6 +60,33 @@ class ChatState:
         with self.persist_jsonl.open("a", encoding="utf-8") as f:
             f.write(json.dumps(rec, ensure_ascii=False) + "\n")
 
+    def export_history(self, path: Path) -> None:
+        """Export the current chat history to *path*.
+
+        The output format is determined by the file extension:
+
+        - ``.json`` → JSON array of messages
+        - ``.md``   → simple Markdown transcript
+        - otherwise → plain text transcript
+        """
+        ext = path.suffix.lower()
+        if ext == ".json":
+            path.write_text(
+                json.dumps(self.history, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+            return
+
+        lines = []
+        for msg in self.history:
+            role = msg.get("role", "")
+            content = msg.get("content", "")
+            if ext == ".md":
+                lines.append(f"**{role}:** {content}")
+            else:
+                lines.append(f"{role}: {content}")
+        path.write_text("\n".join(lines), encoding="utf-8")
+
     # ----------------- topic tracking -----------------
     def update_topic(
         self,

--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -197,6 +197,35 @@ def synthesize(text: str, out_path: Path, client, tts_model: str, tts_voice: str
     print("❌ Impossibile sintetizzare l'audio.")
 
 
+def export_audio_answer(
+    text: str,
+    out_path: Path,
+    *,
+    synth: Any | None = None,
+    client: Any | None = None,
+    tts_model: str = "",
+    tts_voice: str = "",
+) -> None:
+    """Export ``text`` as an audio file to ``out_path``.
+
+    A custom ``synth`` callable can be provided for testing purposes. If not
+    given, ``client``/``tts_model``/``tts_voice`` are used with
+    :func:`synthesize` to generate the audio.
+    """
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    if synth is not None:
+        synth(text, out_path)
+    else:
+        if client is None:
+            raise ValueError("client required if synth not provided")
+        synthesize(text, out_path, client, tts_model, tts_voice)
+
+
+def format_citations(sources: list[dict[str, str]]) -> str:
+    """Return a comma-separated string of source identifiers."""
+    return ", ".join(s.get("id", "") for s in sources if s.get("id"))
+
+
 def append_log(
     q: str,
     a: str,

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+
+from OcchioOnniveggente.src.chat import ChatState
+from OcchioOnniveggente.src.oracle import export_audio_answer, format_citations
+
+
+class DummySynth:
+    def __call__(self, text: str, out_path: Path) -> None:
+        out_path.write_bytes(b"audio")
+
+
+def test_chat_export(tmp_path: Path):
+    st = ChatState()
+    st.push_user("ciao")
+    st.push_assistant("salve")
+
+    txt = tmp_path / "chat.txt"
+    st.export_history(txt)
+    content = txt.read_text(encoding="utf-8")
+    assert "user: ciao" in content
+
+    md = tmp_path / "chat.md"
+    st.export_history(md)
+    md_content = md.read_text(encoding="utf-8")
+    assert "**assistant:** salve" in md_content
+
+    js = tmp_path / "chat.json"
+    st.export_history(js)
+    data = json.loads(js.read_text(encoding="utf-8"))
+    assert data[0]["role"] == "user"
+
+
+def test_format_citations():
+    sources = [{"id": "doc1"}, {"id": "doc2", "score": 0.5}]
+    assert format_citations(sources) == "doc1, doc2"
+
+
+def test_export_audio(tmp_path: Path):
+    out = tmp_path / "ans.wav"
+    export_audio_answer("hello", out, synth=DummySynth())
+    assert out.exists() and out.read_bytes() == b"audio"


### PR DESCRIPTION
## Summary
- Support exporting chat history to text, Markdown or JSON files
- Provide audio export helper with injectable synthesizer
- Add citation formatter for sharing RAG source references

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa3157d9288327ac18e332cf13a8e2