### PR TITLE
feat: enhance RAG with semantic chunking and reranking

### DIFF
--- a/OcchioOnniveggente/src/domain.py
+++ b/OcchioOnniveggente/src/domain.py
@@ -343,6 +343,8 @@ def _try_retrieve(
     if not docstore_path:
         return []
     try:
+        rewrite_model = getattr(settings, "retrieval_rewrite_model", None)
+        rerank_model = getattr(settings, "retrieval_rerank_model", None)
         raw_ctx = retrieve(
             question,
             docstore_path,
@@ -350,6 +352,8 @@ def _try_retrieve(
             topic=topic,
             client=client,
             embed_model=emb_model,
+            rewrite_model=rewrite_model,
+            rerank_model=rerank_model,
         )
     except Exception:
         raw_ctx = []

--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ python scripts/ingest_docs.py --reindex
 ```
 
 Il percorso dell'indice è configurabile con `docstore_path` in `settings.yaml`.
+Il recupero ora combina **BM25 + embedding** e, se configurato, applica un
+mini **cross-encoder** per il reranking. Prima della ricerca la query può
+essere riscritta automaticamente in 1–2 varianti (IT/EN) per migliorarne la
+pertinenza.
 
 Nell'interfaccia grafica sono disponibili le nuove finestre **Dominio…** e
 **Conoscenza…**: la prima consente di definire parole chiave, prompt


### PR DESCRIPTION
## Summary
- implement semantic chunking with dynamic overlap for more coherent document splits
- add optional query rewriting and cross-encoder reranking to retrieval pipeline
- wire settings through domain validator and document new hybrid RAG capabilities

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa354643188327a4381aff416204cd