### PR TITLE
feat: ground answers on compressed retrieval context

### DIFF
--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -141,7 +141,20 @@ def oracle_answer(
         if mode == "concise"
         else " Struttura: 1) sintesi, 2) 2-3 dettagli puntuali, 3) fonti citate [1], [2], …"
     )
-    policy = (policy_prompt or "") + topic_clause + " " + lang_clause + mode_clause
+    grounding_clause = (
+        "Answer ONLY using the passages; if they are insufficient, ask for clarifications."
+        if lang_hint == "en"
+        else "Rispondi SOLO usando i passaggi; se non sono sufficienti, chiedi chiarimenti."
+    )
+    policy = (
+        (policy_prompt or "")
+        + topic_clause
+        + " "
+        + grounding_clause
+        + " "
+        + lang_clause
+        + mode_clause
+    )
 
     messages: List[Dict[str, str]] = []
     if style_prompt:

--- a/tests/test_context_compression.py
+++ b/tests/test_context_compression.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from OcchioOnniveggente.src.retrieval import retrieve, _simple_sentences
+
+
+def test_retrieve_compresses_passages(tmp_path):
+    docs = [
+        {
+            "id": "1",
+            "text": "A apple. B banana. C cherry. D date. E elder. F fig.",
+        }
+    ]
+    p = tmp_path / "idx.json"
+    p.write_text(json.dumps(docs), encoding="utf-8")
+    res = retrieve("banana", p, top_k=1)
+    assert len(_simple_sentences(res[0]["text"])) <= 5
+    assert "banana" in res[0]["text"]

--- a/tests/test_oracle_answer.py
+++ b/tests/test_oracle_answer.py
@@ -42,4 +42,5 @@ def test_oracle_answer_returns_response_and_context():
     model, instructions, messages = client.responses.called_with
     assert model == "test-model"
     assert "Rispondi in italiano." in instructions
+    assert "Rispondi SOLO usando i passaggi" in instructions
     assert messages[-1] == {"role": "user", "content": "Che cos'è?"}


### PR DESCRIPTION
## Summary
- compress retrieved passages to top relevant sentences for cleaner context
- ensure LLM instructions demand answers only from provided passages and ask for clarifications if needed
- test passage compression and updated policy prompt

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa3691893083278a173fd359b5952c