### PR TITLE
Add conversational memory summary and pinned shortlist

### DIFF
--- a/tests/test_chat_memory.py
+++ b/tests/test_chat_memory.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from OcchioOnniveggente.src.chat import ChatState
+
+
+def test_summary_and_pinned_shortlist():
+    st = ChatState(max_turns=1, pinned_limit=2)
+    st.push_user("ciao")
+    st.push_assistant("salve")
+    st.push_user("come va?")
+    st.push_assistant("bene")
+    assert "user: ciao" in st.summary
+    assert "assistant: salve" in st.summary
+    assert len(st.history) == 2 and st.history[-1]["content"] == "bene"
+    st.pin_message("uno")
+    st.pin_message("due")
+    st.pin_message("tre")
+    assert st.pinned_shortlist() == ["due", "tre"]

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -32,10 +32,15 @@ def test_update_topic_detects_change():
     client = DummyEmbClient(mapping)
     chat = ChatState()
 
+    chat.push_user("tema1")
     assert chat.update_topic("tema1", client, "m") is False
+    chat.push_user("tema1 follow")
     assert chat.update_topic("tema1 follow", client, "m") is False
+    chat.push_user("tema2")
     assert chat.update_topic("tema2", client, "m") is True
     assert chat.topic_text == "tema2"
+    assert chat.summary  # previous history summarized
+    assert len(chat.history) == 1 and chat.history[0]["content"] == "tema2"
 
 
 def test_retrieve_filters_by_topic(tmp_path: Path):


### PR DESCRIPTION
## Summary
- track conversation summary and limit pinned messages in ChatState
- soft-reset context on topic changes to keep style but drop technical history
- test coverage for summary management and pinned shortlist

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa37b969808327afd779e4c32cba84