### PR TITLE
feat: adaptive validator with topic suggestions

### DIFF
--- a/OcchioOnniveggente/src/main.py
+++ b/OcchioOnniveggente/src/main.py
@@ -442,7 +442,7 @@ def main() -> None:
                 except Exception:
                     DOCSTORE_PATH = "DataBase/index.json"
                     TOPK = 3
-                ok, context, clarify, reason = validate_question(
+                ok, context, clarify, reason, suggestion = validate_question(
                     pending_q,
                     client=client,
                     emb_model=EMB_MODEL,
@@ -453,6 +453,11 @@ def main() -> None:
                 )
                 if DEBUG:
                     say(f"[VAL] {reason}", quiet=False)
+                if not ok and clarify and suggestion and suggestion != pending_topic:
+                    say(f"Vuoi cambiare argomento in: {suggestion}?", quiet=args.quiet)
+                    dlg.end_processing()
+                    dlg.transition(DialogState.LISTENING)
+                    continue
                 if not ok and clarify:
                     say("🤔 Puoi chiarire meglio la tua domanda?", quiet=args.quiet)
                     dlg.end_processing()

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,48 @@
+import json
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "OcchioOnniveggente"))
+from src.domain import validate_question
+
+
+def test_adaptive_threshold(tmp_path):
+    dom = SimpleNamespace(enabled=True, keywords=["science"], accept_threshold=0.5)
+    settings = SimpleNamespace(domain=dom)
+    history = [
+        {"role": "user", "content": "football"},
+        {"role": "user", "content": "music"},
+        {"role": "user", "content": "weather"},
+    ]
+    ok, ctx, clarify, reason, sugg = validate_question(
+        "random", settings=settings, history=history
+    )
+    assert "thr=" in reason
+    thr = float(reason.split("thr=")[1].split()[0])
+    assert thr > 0.5
+
+
+def test_topic_switch_suggestion(tmp_path):
+    index = tmp_path / "index.json"
+    data = {
+        "documents": [
+            {"id": "1", "text": "Cats are animals", "topic": "animals"},
+            {"id": "2", "text": "car goes fast", "topic": "vehicles"},
+        ]
+    }
+    index.write_text(json.dumps(data), encoding="utf-8")
+
+    dom = SimpleNamespace(
+        enabled=True,
+        keywords=["cat"],
+        accept_threshold=0.1,
+        clarify_margin=0.15,
+        topic="animals",
+    )
+    settings = SimpleNamespace(domain=dom)
+    ok, ctx, clarify, reason, sugg = validate_question(
+        "car", settings=settings, docstore_path=index, top_k=1
+    )
+    assert clarify
+    assert sugg == "vehicles"


### PR DESCRIPTION
## Summary
- adjust accept threshold dynamically based on recent user focus
- suggest topic changes when questions are borderline
- prompt users to switch topics in main dialog flow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa390064f08327b1a952a1d2f2fab7