### PR TITLE
feat: add explicit dialogue states and idle countdown

### DIFF
--- a/OcchioOnniveggente/src/dialogue.py
+++ b/OcchioOnniveggente/src/dialogue.py
@@ -13,6 +13,7 @@ class DialogState(Enum):
     LISTENING = auto()
     THINKING = auto()
     SPEAKING = auto()
+    INTERRUPTED = auto()
 
 
 @dataclass
@@ -32,7 +33,12 @@ class DialogueManager:
     def transition(self, new_state: DialogState) -> None:
         """Transition to a new state and refresh deadline when appropriate."""
         self.state = new_state
-        if new_state in (DialogState.AWAKE, DialogState.LISTENING, DialogState.SPEAKING):
+        if new_state in (
+            DialogState.AWAKE,
+            DialogState.LISTENING,
+            DialogState.SPEAKING,
+            DialogState.INTERRUPTED,
+        ):
             self.refresh_deadline()
 
     def start_processing(self) -> int:


### PR DESCRIPTION
## Summary
- extend dialogue state machine with `INTERRUPTED` state
- show 60s inactivity countdown and reset on any user input
- handle barge-in by switching to interrupted state before listening again

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa3a9790b4832789c0bb62a82e946e