### PR TITLE
Fix append_log f-string to avoid SyntaxError

### DIFF
--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -259,9 +259,11 @@ def append_log(
     def clean(s: str) -> str:
         return s.replace('"', "'")
 
-    src_str = ";".join(f"{s.get('id','')}:{s.get('score',0):.2f}" for s in (sources or []))
+    src_str = ";".join(
+        f"{s.get('id','')}:{s.get('score',0):.2f}" for s in (sources or [])
+    )
     line = (
-        f'"{ts}","{lang}","{clean(topic or '')}",'
+        f'"{ts}","{lang}","{clean(topic or "")}",'
         f'"{clean(q)}","{clean(a)}","{src_str}"\n'
     )
     if not log_path.exists():


### PR DESCRIPTION
## Summary
- Avoid f-string quoting issue in `append_log`
- Minor refactor for readability

## Testing
- `pytest -q`
- `python -m src.ui` *(fails: PortAudio library not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa43de0b1483279160e4922abb3b8a