### PR TITLE
feat: fallback without markdown2

### DIFF
--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -36,7 +36,12 @@ import numpy as np
 import sounddevice as sd
 import websockets
 import yaml
-from markdown2 import markdown
+try:  # markdown2 è opzionale
+    from markdown2 import markdown
+except ImportError:  # pragma: no cover - fallback se non installato
+    def markdown(text: str, *_, **__):
+        """Ritorna il testo originale se markdown2 non è disponibile."""
+        return text
 from openai import OpenAI
 import re
 import webbrowser


### PR DESCRIPTION
## Summary
- allow running UI even when `markdown2` is missing by providing a simple fallback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa460fca008327b57f3c5fa7aa734c