### PR TITLE
Ensure validator returns consistent tuple

### DIFF
--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -46,3 +46,12 @@ def test_topic_switch_suggestion(tmp_path):
     )
     assert clarify
     assert sugg == "vehicles"
+
+
+def test_disabled_returns_full_tuple():
+    dom = SimpleNamespace(enabled=False, keywords=["science"])
+    settings = SimpleNamespace(domain=dom)
+    ok, ctx, clarify, reason, sugg = validate_question("hi", settings=settings)
+    assert ok
+    assert reason == "disabled"
+    assert sugg is None


### PR DESCRIPTION
## Summary
- guarantee `validate_question` always returns five values
- add regression test for disabled-domain early exit

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa492da30c83278a5bf5ce18b03426