### PR TITLE
Improve realtime speech pipeline with fast STT and TTS streaming

### DIFF
--- a/OcchioOnniveggente/scripts/realtime_server.py
+++ b/OcchioOnniveggente/scripts/realtime_server.py
@@ -18,9 +18,10 @@ if str(ROOT) not in sys.path:
 
 from src.config import Settings
 from src.hotword import strip_hotword_prefix
-from src.oracle import transcribe, oracle_answer
+from src.oracle import fast_transcribe, oracle_answer
 from src.retrieval import retrieve
 from src.chat import ChatState
+from langdetect import detect
 
 CHUNK_MS = 20
 # soglia più permissiva per captare parlato anche con microfoni poco sensibili
@@ -109,6 +110,29 @@ class RTSession:
         except Exception:
             pass
 
+    async def stream_tts_pcm(self, text: str, client: Any) -> None:
+        """Sintetizza e invia ``text`` in formato PCM con latenza ridotta."""
+
+        self.state = "tts"
+        self.barge = False
+        try:
+            with client.audio.speech.with_streaming_response.create(
+                model=self.SET.openai.tts_model,
+                voice=self.SET.openai.tts_voice,
+                input=text,
+                response_format="pcm",
+                sample_rate=self.client_sr,
+            ) as resp:
+                for chunk in resp.iter_bytes(chunk_size=960):
+                    await self.ws.send(chunk)
+                    await asyncio.sleep(0)
+                    if self.barge:
+                        break
+        except Exception:
+            pass
+        self.state = "idle"
+        self.barge = False
+
     async def stream_sentences(self, text: str, client: Any) -> None:
         """Sintetizza ``text`` frase per frase, consentendo il barge-in
         solo ai confini di frase.
@@ -180,12 +204,19 @@ class RTSession:
         load_dotenv()
         client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 
-        text, lang = transcribe(
-            self.in_wav, client, self.SET.openai.stt_model, debug=self.SET.debug
+        text = fast_transcribe(
+            self.in_wav, client, self.SET.openai.stt_model
         )
         if not text.strip():
             await self.send_partial("…silenzio…")
             return
+
+        try:
+            lang = detect(text)
+        except Exception:
+            lang = "it"
+        if lang not in ("it", "en"):
+            lang = "it"
 
         print(f"🗣️ {text.strip()}", flush=True)
         now = time.time()
@@ -217,7 +248,7 @@ class RTSession:
 
         if self.chat_enabled:
             self.chat.push_user(text)
-        ans = oracle_answer(
+        ans, _ = oracle_answer(
             text,
             lang,
             client,
@@ -228,9 +259,12 @@ class RTSession:
         )
         if self.chat_enabled:
             self.chat.push_assistant(ans)
-        await self.send_answer(ans)
 
-        await self.stream_sentences(ans, client)
+        first_words = " ".join(ans.split()[:5])
+        await self.send_partial(first_words)
+        tts_task = asyncio.create_task(self.stream_tts_pcm(ans, client))
+        await self.send_answer(ans)
+        await tts_task
 
 async def handler(ws):
     SET = Settings.model_validate_yaml(ROOT / "settings.yaml")

--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -46,6 +46,25 @@ def _score_lang(text: str, lang: str, *, debug: bool = False) -> float:
     return score
 
 
+def fast_transcribe(path_or_bytes, client, stt_model: str, lang_hint: str | None = None) -> str:
+    """Perform a single transcription call with optional language hint."""
+
+    kwargs = {}
+    if lang_hint in ("it", "en"):
+        kwargs["language"] = lang_hint
+
+    if isinstance(path_or_bytes, (str, Path)):
+        with open(path_or_bytes, "rb") as f:
+            tx = client.audio.transcriptions.create(
+                model=stt_model, file=f, **kwargs
+            )
+    else:
+        tx = client.audio.transcriptions.create(
+            model=stt_model, file=path_or_bytes, **kwargs
+        )
+    return (getattr(tx, "text", "") or "").strip()
+
+
 def transcribe(path: Path, client, stt_model: str, *, debug: bool = False) -> Tuple[str, str]:
     def _call_transcription(**kwargs) -> str:
         def do_call() -> str:


### PR DESCRIPTION
## Summary
- add `fast_transcribe` helper to perform a single STT call with optional language hint
- stream TTS audio in PCM with new `stream_tts_pcm`
- realtime server now uses fast transcription, detects language once, and sends early partial text while streaming audio

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aadf1c74588327b1b2dd509c0f0e6a