### PR TITLE
Use JSON response format for transcribe

### DIFF
--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -34,7 +34,7 @@ def transcribe(path: Path, client, stt_model: str, *, debug: bool = False) -> Tu
             tx = client.audio.transcriptions.create(
                 model=stt_model,
                 file=f,
-                response_format="verbose_json",
+                response_format="json",
             )
     except openai.OpenAIError as e:
         print(f"Errore OpenAI: {e}")


### PR DESCRIPTION
## Summary
- switch audio transcription call to JSON output to support models that do not allow `verbose_json`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aaee5630208327b236b83de90ca4e2