### PR TITLE
Load OpenAI API key from configuration

### DIFF
--- a/OcchioOnniveggente/src/main.py
+++ b/OcchioOnniveggente/src/main.py
@@ -161,7 +161,6 @@ def main() -> None:
     say("Occhio Onniveggente · Oracolo ✨", quiet=args.quiet)
 
     load_dotenv()
-    client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 
     cfg_path = Path("settings.yaml")
     if cfg_path.exists():
@@ -174,6 +173,9 @@ def main() -> None:
     else:
         print("⚠️ settings.yaml non trovato, uso impostazioni di default.")
         SET = Settings()
+
+    api_key = os.environ.get("OPENAI_API_KEY") or getattr(SET.openai, "api_key", "")
+    client = OpenAI(api_key=api_key) if api_key else OpenAI()
 
     DEBUG = bool(SET.debug) and (not args.quiet)
 

--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -824,11 +824,13 @@ class OracoloUI(tk.Tk):
         self.chat_state.push_user(text)
         self.last_sources = []
         try:
-            client = OpenAI()
+            openai_conf = self.settings.get("openai", {})
+            api_key = openai_conf.get("api_key") or os.environ.get("OPENAI_API_KEY")
+            client = OpenAI(api_key=api_key) if api_key else OpenAI()
             self.chat_state.update_topic(
                 text,
                 client,
-                self.settings.get("openai", {}).get("embed_model", "text-embedding-3-small"),
+                openai_conf.get("embed_model", "text-embedding-3-small"),
                 threshold=float(self.topic_threshold.get()),
             )
             style_prompt = self.settings.get("style_prompt", "") if self.style_var.get() else ""
@@ -906,8 +908,9 @@ class OracoloUI(tk.Tk):
         if not path:
             return
         try:
-            client = OpenAI()
             openai_conf = self.settings.get("openai", {})
+            api_key = openai_conf.get("api_key") or os.environ.get("OPENAI_API_KEY")
+            client = OpenAI(api_key=api_key) if api_key else OpenAI()
             tts_model = openai_conf.get("tts_model", "gpt-4o-mini-tts")
             tts_voice = openai_conf.get("tts_voice", "alloy")
             synthesize(self.last_answer, Path(path), client, tts_model, tts_voice)
@@ -1026,7 +1029,9 @@ class OracoloUI(tk.Tk):
             lang = self.lang_map.get(lang_var.get(), "auto")
             start = time.time()
             try:
-                client = OpenAI()
+                openai_conf = self.settings.get("openai", {})
+                api_key = openai_conf.get("api_key") or os.environ.get("OPENAI_API_KEY")
+                client = OpenAI(api_key=api_key) if api_key else OpenAI()
             except Exception:
                 client = None
             ok, ctx, _clar, reason, _ = validate_question(
@@ -1129,7 +1134,9 @@ class OracoloUI(tk.Tk):
         win = tk.Toplevel(self)
         win.title("Limiti OpenAI")
         try:
-            client = OpenAI()
+            openai_conf = self.settings.get("openai", {})
+            api_key = openai_conf.get("api_key") or os.environ.get("OPENAI_API_KEY")
+            client = OpenAI(api_key=api_key) if api_key else OpenAI()
             model = self.settings.get("llm_model", "gpt-4o")
             info = client.models.retrieve(model)
             ttk.Label(win, text=f"Modello: {info.id}").pack(anchor="w", padx=8, pady=4)


### PR DESCRIPTION
## Summary
- Read OpenAI API key from `settings.yaml` or environment and use it when initializing the client
- Pass configured API key in UI chat and audio export actions to avoid missing API key errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaf15d6d448327a674908058469e66