### PR TITLE
feat: add structured logging with session context

### DIFF
--- a/OcchioOnniveggente/src/logging_utils.py
+++ b/OcchioOnniveggente/src/logging_utils.py
@@ -1,10 +1,40 @@
+"""Utility per la configurazione del logging strutturato.
+
+Il modulo imposta un logging asincrono basato su ``QueueListener`` e
+``RotatingFileHandler``. I messaggi vengono serializzati in JSON e
+arricchiti con un identificativo di sessione, così da poterli analizzare con
+strumenti esterni senza confonderli con l'output destinato all'utente.
+"""
+
+import json
 import logging
 from logging.handlers import RotatingFileHandler, QueueHandler, QueueListener
 from pathlib import Path
 from queue import Queue
+from typing import Optional
 
 
-def setup_logging(log_path: Path, level: int = logging.INFO) -> QueueListener:
+class JsonFormatter(logging.Formatter):
+    """Formatter che serializza i record in JSON."""
+
+    def format(self, record: logging.LogRecord) -> str:  # type: ignore[override]
+        log_record = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+        }
+        session_id = getattr(record, "session_id", None)
+        if session_id is not None:
+            log_record["session_id"] = session_id
+        return json.dumps(log_record, ensure_ascii=False)
+
+
+def setup_logging(
+    log_path: Path,
+    level: int = logging.INFO,
+    session_id: Optional[str] = None,
+) -> QueueListener:
     """Configure logging with a queue and rotating file handler.
 
     Parameters
@@ -32,18 +62,29 @@ def setup_logging(log_path: Path, level: int = logging.INFO) -> QueueListener:
     root.setLevel(level)
     root.addHandler(queue_handler)
 
+    # Ensure each record has a session identifier for context
+    old_factory = logging.getLogRecordFactory()
+
+    def record_factory(*args, **kwargs):
+        record = old_factory(*args, **kwargs)
+        record.session_id = session_id or "-"
+        return record
+
+    logging.setLogRecordFactory(record_factory)
+
     # Rotating file handler and console handler run in listener thread
-    fmt = logging.Formatter(
-        "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
+    json_fmt = JsonFormatter(datefmt="%Y-%m-%dT%H:%M:%S")
     file_handler = RotatingFileHandler(
         log_path, maxBytes=1_000_000, backupCount=3, encoding="utf-8"
     )
-    file_handler.setFormatter(fmt)
+    file_handler.setFormatter(json_fmt)
 
+    console_fmt = logging.Formatter(
+        "%(asctime)s [%(levelname)s] %(name)s [%(session_id)s]: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
     console_handler = logging.StreamHandler()
-    console_handler.setFormatter(fmt)
+    console_handler.setFormatter(console_fmt)
 
     listener = QueueListener(queue, file_handler, console_handler)
     listener.start()

--- a/OcchioOnniveggente/src/main.py
+++ b/OcchioOnniveggente/src/main.py
@@ -8,6 +8,7 @@ import difflib
 import unicodedata
 import argparse
 import threading
+import uuid
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -154,7 +155,8 @@ def oracle_greeting(lang: str) -> str:
 def main() -> None:
     _ensure_utf8_stdout()
 
-    listener = setup_logging(Path("data/logs/oracolo.log"))
+    session_id = uuid.uuid4().hex
+    listener = setup_logging(Path("data/logs/oracolo.log"), session_id=session_id)
 
     parser = argparse.ArgumentParser(description="Occhio Onniveggente · Oracolo")
     parser.add_argument("--autostart", action="store_true", help="Avvia direttamente senza prompt input()")

--- a/tests/test_structured_logging.py
+++ b/tests/test_structured_logging.py
@@ -1,0 +1,25 @@
+import json
+import logging
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from OcchioOnniveggente.src.logging_utils import setup_logging
+
+
+def test_setup_logging_produces_json(tmp_path: Path):
+    prev_factory = logging.getLogRecordFactory()
+    log_path = tmp_path / "log.json"
+    listener = setup_logging(log_path, session_id="sess-1")
+    try:
+        logging.getLogger("test").info("hello")
+    finally:
+        listener.stop()
+        logging.setLogRecordFactory(prev_factory)
+
+    lines = log_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    data = json.loads(lines[0])
+    assert data["message"] == "hello"
+    assert data["session_id"] == "sess-1"
+    assert data["level"] == "INFO"


### PR DESCRIPTION
## Summary
- add JSON-based structured logging with session id support
- tag log records with a unique session id at startup
- test that logging writes JSON records with session context

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aafb79e8648327af92d72419d516e6