### PR TITLE
Speak only summary

### DIFF
--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 import io
+import re
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
@@ -261,4 +262,27 @@ def append_log(
         )
     with log_path.open("a", encoding="utf-8") as f:
         f.write(line)
+
+
+def extract_summary(answer: str) -> str:
+    """Extract the summary part from a structured oracle answer.
+
+    The oracle answer is expected to follow the structure:
+    "1) Sintesi: ... 2) ... 3) ...". This function returns only the
+    text inside the first section, without the leading "1)" or
+    "Sintesi:" labels. If the expected pattern is not found, the
+    original text is returned unchanged.
+    """
+
+    match = re.search(
+        r"1\)\s*(?:Sintesi:)?\s*(.*?)(?:\n\s*2\)|$)", answer, flags=re.S | re.I
+    )
+    if match:
+        return match.group(1).strip()
+
+    match = re.search(r"Sintesi:\s*(.*)", answer, flags=re.S | re.I)
+    if match:
+        return match.group(1).strip()
+
+    return answer.strip()
 

--- a/tests/test_extract_summary.py
+++ b/tests/test_extract_summary.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from OcchioOnniveggente.src.oracle import extract_summary
+
+
+def test_extract_summary_structured():
+    text = "1) Sintesi: Questo è il riassunto.\n2) Dettagli: punto A; punto B.\n3) Fonti: [1]"
+    assert extract_summary(text) == "Questo è il riassunto."
+
+
+def test_extract_summary_no_structure():
+    text = "Risposta semplice senza struttura."
+    assert extract_summary(text) == "Risposta semplice senza struttura."


### PR DESCRIPTION
## Summary
- Add `extract_summary` helper to isolate the concise thought from full structured answers.
- Update dialogue flow to log the entire response but have the oracle speak only the synthesized summary.
- Cover summary extraction with unit tests.

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab069726248327b22d4de6b6bbb0a1