### PR TITLE
Enable multi-turn wake with 50s idle timeout

### DIFF
--- a/OcchioOnniveggente/scripts/realtime_server.py
+++ b/OcchioOnniveggente/scripts/realtime_server.py
@@ -137,7 +137,7 @@ class RTSession:
             self.wake_phrases = list(getattr(setts.wake, "it_phrases", [])) + list(
                 getattr(setts.wake, "en_phrases", [])
             )
-        self.idle_timeout = float(getattr(setts.wake, "idle_timeout", 60.0))
+        self.idle_timeout = float(getattr(setts.wake, "idle_timeout", 50.0))
 
         self.chat_enabled = bool(getattr(getattr(setts, "chat", None), "enabled", False))
         self.chat = ChatState(
@@ -162,7 +162,7 @@ class RTSession:
             self.wake_phrases = list(getattr(setts.wake, "it_phrases", [])) + list(
                 getattr(setts.wake, "en_phrases", [])
             )
-        self.idle_timeout = float(getattr(setts.wake, "idle_timeout", 60.0))
+        self.idle_timeout = float(getattr(setts.wake, "idle_timeout", 50.0))
 
         self.chat_enabled = bool(getattr(getattr(setts, "chat", None), "enabled", False))
         self.chat = ChatState(

--- a/OcchioOnniveggente/settings.yaml
+++ b/OcchioOnniveggente/settings.yaml
@@ -94,8 +94,8 @@ oracle_system: >
 # Hotword / risveglio
 wake:
   enabled: true           # usa la hotword; se metti false parla sempre (sconsigliato)
-  single_turn: true       # dopo 1 risposta torna a SLEEP; metti false per dialogo continuo
-  idle_timeout: 60        # secondi di inattività prima di tornare a SLEEP
+  single_turn: false      # dopo 1 risposta resta attivo finché c'è attività
+  idle_timeout: 50        # secondi di inattività prima di tornare a SLEEP
 
   # Frasi riconosciute (tolleranti a maiuscole, punteggiatura, piccoli errori STT)
   it_phrases:

--- a/OcchioOnniveggente/src/config.py
+++ b/OcchioOnniveggente/src/config.py
@@ -5,8 +5,8 @@ import yaml
 from pydantic import BaseModel, Field
 class WakeConfig(BaseModel):
     enabled: bool = True
-    single_turn: bool = True
-    idle_timeout: float = 60.0
+    single_turn: bool = False
+    idle_timeout: float = 50.0
     it_phrases: List[str] = Field(default_factory=lambda: ["ciao oracolo", "ehi oracolo", "salve oracolo", "ciao, oracolo"])
     en_phrases: List[str] = Field(default_factory=lambda: ["hello oracle", "hey oracle", "hi oracle", "hello, oracle"])
 

--- a/OcchioOnniveggente/src/main.py
+++ b/OcchioOnniveggente/src/main.py
@@ -270,7 +270,7 @@ def main() -> None:
     WAKE_EN = ["hello oracle", "hey oracle", "hi oracle", "hello, oracle"]
     WAKE_ENABLED = True
     WAKE_SINGLE_TURN = False
-    IDLE_TIMEOUT = 60.0  # secondi di inattività prima di tornare a SLEEP
+    IDLE_TIMEOUT = 50.0  # secondi di inattività prima di tornare a SLEEP
 
     try:
         if getattr(SET, "wake", None) is not None:

--- a/OcchioOnniveggente/src/realtime_oracolo.py
+++ b/OcchioOnniveggente/src/realtime_oracolo.py
@@ -198,7 +198,7 @@ async def _run(url: str, sr: int, barge_threshold: float) -> None:
         "barge_threshold": barge_threshold,
         "ducking": False,
     }
-    dlg = DialogueManager(idle_timeout=60)
+    dlg = DialogueManager(idle_timeout=50)
     dlg.transition(DialogState.LISTENING)
 
     async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:

--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -957,7 +957,7 @@ class OracoloUI(tk.Tk):
 
     def _poll_idle(self) -> None:
         now = time.time()
-        timeout = self.settings.get("wake", {}).get("idle_timeout", 60)
+        timeout = self.settings.get("wake", {}).get("idle_timeout", 50)
         if now - self.last_activity > timeout:
             self.status_var.set("😴 Dormiente — dì Ciao Oracolo per riattivarmi")
         elif self.status_var.get().startswith("😴"):
@@ -1617,7 +1617,7 @@ class OracoloUI(tk.Tk):
         win.configure(bg=self._bg)
 
         wake = self.settings.setdefault("wake", {})
-        timeout_var = tk.IntVar(value=int(wake.get("idle_timeout", 60)))
+        timeout_var = tk.IntVar(value=int(wake.get("idle_timeout", 50)))
         it_var = tk.StringVar(value=", ".join(wake.get("it_phrases", [])))
         en_var = tk.StringVar(value=", ".join(wake.get("en_phrases", [])))
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ definire più **profili** preconfigurati. Ad esempio:
 ```yaml
 wake:
   enabled: true
-  single_turn: true
+  single_turn: false
+  idle_timeout: 50
   it_phrases: ["ciao oracolo"]
 
 profiles:


### PR DESCRIPTION
## Summary
- keep the oracle awake for follow-up questions by default
- switch idle timeout to 50 seconds before auto-sleep
- sync realtime server, UI, and docs with new wake behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab0a7bda7483279897ffa6a86dbe87