### PR TITLE
Improve domain filtering for off-topic questions

### DIFF
--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -55,3 +55,13 @@ def test_disabled_returns_full_tuple():
     assert ok
     assert reason == "disabled"
     assert sugg is None
+
+
+def test_off_topic_rejected():
+    dom = SimpleNamespace(enabled=True, keywords=["arte", "collezione"], accept_threshold=0.5)
+    settings = SimpleNamespace(domain=dom)
+    q = "Parli della squadra di calcio del Milan"
+    ok, ctx, clarify, reason, sugg = validate_question(q, settings=settings)
+    assert not ok
+    assert not clarify
+    assert ctx == []


### PR DESCRIPTION
## Summary
- ensure boost term handling via `has_boost`
- reject questions lacking domain keywords
- add regression test for off-topic Milan query

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab0fa27d38832787b275c5c722f0c0