### PR TITLE
Allow profiles to lock chat topic

### DIFF
--- a/OcchioOnniveggente/src/chat.py
+++ b/OcchioOnniveggente/src/chat.py
@@ -14,6 +14,7 @@ class ChatState:
     history: List[Dict[str, str]] = field(default_factory=list)
     topic_emb: Optional[np.ndarray] = field(default=None, repr=False)
     topic_text: Optional[str] = None
+    topic_locked: bool = False
     pinned: List[str] = field(default_factory=list)
     summary: str = ""
     pinned_limit: int = 5
@@ -127,6 +128,8 @@ class ChatState:
         Ritorna True se è stato rilevato un cambio di tema rispetto al
         topic precedente.
         """
+        if self.topic_locked:
+            return False
         if not text or client is None or not emb_model:
             return False
         try:

--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -771,6 +771,7 @@ class OracoloUI(tk.Tk):
         if prof.get("domain"):
             self.settings["domain"] = prof["domain"]
             self.chat_state.topic_text = prof["domain"].get("topic")
+            self.chat_state.topic_locked = True
         if prof.get("docstore_path"):
             self.settings["docstore_path"] = prof["docstore_path"]
         if prof.get("chat_memory"):
@@ -827,12 +828,13 @@ class OracoloUI(tk.Tk):
             openai_conf = self.settings.get("openai", {})
             api_key = openai_conf.get("api_key") or os.environ.get("OPENAI_API_KEY")
             client = OpenAI(api_key=api_key) if api_key else OpenAI()
-            self.chat_state.update_topic(
-                text,
-                client,
-                openai_conf.get("embed_model", "text-embedding-3-small"),
-                threshold=float(self.topic_threshold.get()),
-            )
+            if not self.chat_state.topic_locked:
+                self.chat_state.update_topic(
+                    text,
+                    client,
+                    openai_conf.get("embed_model", "text-embedding-3-small"),
+                    threshold=float(self.topic_threshold.get()),
+                )
             style_prompt = self.settings.get("style_prompt", "") if self.style_var.get() else ""
             lang = self.lang_map.get(self.lang_choice.get(), "auto")
             mode = self.mode_map.get(self.mode_choice.get(), "detailed")


### PR DESCRIPTION
## Summary
- add `topic_locked` to chat state to prevent automatic topic updates
- lock chat topic when applying a profile and skip topic detection if locked

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab137b0bdc83279af88a0f42a6175c