### PR TITLE
Fix validate_question call in UI

### DIFF
--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -844,13 +844,7 @@ class OracoloUI(tk.Tk):
                 top_k=top_k,
                 embed_model=openai_conf.get("embed_model", "text-embedding-3-small"),
                 topic=self.chat_state.topic_text,
-
-                embed_model=openai_conf.get("embed_model", "text-embedding-3-small"),
-                topic=(self.settings.get("domain", {}) or {}).get("profile"),
-                topic=(self.settings.get("domain", {}).get("profile")),
-                embed_model=openai_conf.get("embed_model", "text-embedding-3-small"),
                 history=self.chat_state.history,
-main
             )
             if not ok:
                 if needs_clar:


### PR DESCRIPTION
## Summary
- remove duplicated arguments from `validate_question` call in UI to resolve syntax error

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab2c5a6a48832799ff7968d7a82f45