### PR TITLE
Use JSON lines for append_log and include session metadata

### DIFF
--- a/OcchioOnniveggente/src/main.py
+++ b/OcchioOnniveggente/src/main.py
@@ -707,6 +707,7 @@ def main() -> None:
                     pending_q,
                     pending_full_answer or pending_answer,
                     LOG_PATH,
+                    session_id=session_id,
                     lang=pending_lang,
                     topic=pending_topic,
                     sources=pending_sources,

--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 import io
+import json
 import re
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
@@ -251,31 +252,27 @@ def append_log(
     a: str,
     log_path: Path,
     *,
+    session_id: str,
     lang: str = "",
     topic: str | None = None,
     sources: list[dict[str, str]] | None = None,
 ) -> None:
-    """Append a structured CSV line with optional metadata."""
+    """Append one JSON object per line with optional metadata."""
     log_path.parent.mkdir(parents=True, exist_ok=True)
     ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
-    def clean(s: str) -> str:
-        return s.replace('"', "'")
+    record = {
+        "timestamp": ts,
+        "session_id": session_id,
+        "lang": lang,
+        "topic": topic or "",
+        "question": q,
+        "answer": a,
+        "sources": sources or [],
+    }
 
-    src_str = ";".join(
-        f"{s.get('id','')}:{s.get('score',0):.2f}" for s in (sources or [])
-    )
-    line = (
-        f'"{ts}","{lang}","{clean(topic or "")}",'
-        f'"{clean(q)}","{clean(a)}","{src_str}"\n'
-    )
-    if not log_path.exists():
-        log_path.write_text(
-            '"timestamp","lang","topic","question","answer","sources"\n',
-            encoding="utf-8",
-        )
     with log_path.open("a", encoding="utf-8") as f:
-        f.write(line)
+        f.write(json.dumps(record, ensure_ascii=False) + "\n")
 
 
 def extract_summary(answer: str) -> str:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from pathlib import Path
 
@@ -6,15 +7,22 @@ from OcchioOnniveggente.src.oracle import append_log
 
 
 def test_append_log_writes_metadata(tmp_path: Path):
-    log = tmp_path / "log.csv"
+    log = tmp_path / "log.jsonl"
     append_log(
         "q",
         "a",
         log,
+        session_id="sess-1",
         lang="it",
         topic="neuro",
         sources=[{"id": "doc1", "score": 0.9}],
     )
     data = log.read_text(encoding="utf-8").strip().splitlines()
-    assert data[0] == '"timestamp","lang","topic","question","answer","sources"'
-    assert "doc1:0.90" in data[1]
+    assert len(data) == 1
+    rec = json.loads(data[0])
+    assert rec["session_id"] == "sess-1"
+    assert rec["lang"] == "it"
+    assert rec["topic"] == "neuro"
+    assert rec["question"] == "q"
+    assert rec["answer"] == "a"
+    assert rec["sources"] == [{"id": "doc1", "score": 0.9}]


### PR DESCRIPTION
## Summary
- Switch append_log to JSONL output and include session_id, language, topic, and sources metadata.
- Pass session_id when logging conversations.
- Adjust tests to verify JSON line logging behavior.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab36a632088327bbd94aab7bbb5ef0