### PR TITLE
Persist session language across turns

### DIFF
--- a/OcchioOnniveggente/src/language_session.py
+++ b/OcchioOnniveggente/src/language_session.py
@@ -1,0 +1,26 @@
+"""Utilities for managing conversation language preference."""
+from __future__ import annotations
+
+
+def update_language(current: str | None, detected: str | None, text: str) -> str:
+    """Return the effective session language.
+
+    - ``current`` is the previously selected language (``"it"`` or ``"en"``).
+    - ``detected`` is the language guessed from the latest user input.
+    - ``text`` is the raw user text which may contain an explicit
+      language request.
+    The function preserves ``current`` unless ``text`` explicitly asks for a
+    change. If no language has yet been chosen, ``detected`` is used. The
+    default fallback is Italian (``"it"``).
+    """
+
+    t = (text or "").lower()
+    if "inglese" in t or "english" in t:
+        return "en"
+    if "italiano" in t or "italian" in t:
+        return "it"
+    if current in ("it", "en"):
+        return current
+    if detected in ("it", "en"):
+        return detected
+    return "it"

--- a/tests/test_language_persistence.py
+++ b/tests/test_language_persistence.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+# Ensure repository root is on the path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from OcchioOnniveggente.src.language_session import update_language
+
+
+def test_language_persists_across_turns():
+    lang = None
+    # First turn detected english
+    lang = update_language(lang, "en", "hello oracle")
+    assert lang == "en"
+
+    # Second turn user speaks italian but doesn't request change
+    lang = update_language(lang, "it", "ciao oracolo")
+    assert lang == "en"
+
+    # Third turn user explicitly asks to switch to Italian
+    lang = update_language(lang, "it", "parli in italiano?")
+    assert lang == "it"


### PR DESCRIPTION
## Summary
- Track conversation language in session and only change when user explicitly asks
- Introduce `update_language` helper to centralize language selection logic
- Add regression test to ensure language choice persists across multiple turns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab36ff3ca88327ac4ce26102e8d5a1