### PR TITLE
Add session id to append_log and test

### DIFF
--- a/OcchioOnniveggente/src/main.py
+++ b/OcchioOnniveggente/src/main.py
@@ -710,6 +710,7 @@ def main() -> None:
                     lang=pending_lang,
                     topic=pending_topic,
                     sources=pending_sources,
+                    session_id=session_id,
                 )
                 if pending_sources:
                     print("📚 Fonti:")

--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 import io
 import re
+import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
@@ -254,10 +255,16 @@ def append_log(
     lang: str = "",
     topic: str | None = None,
     sources: list[dict[str, str]] | None = None,
-) -> None:
-    """Append a structured CSV line with optional metadata."""
+    session_id: str | None = None,
+) -> str:
+    """Append a structured CSV line with optional metadata.
+
+    If ``session_id`` is not provided, a new one is generated and returned.
+    """
     log_path.parent.mkdir(parents=True, exist_ok=True)
     ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    if session_id is None:
+        session_id = uuid.uuid4().hex
 
     def clean(s: str) -> str:
         return s.replace('"', "'")
@@ -266,16 +273,17 @@ def append_log(
         f"{s.get('id','')}:{s.get('score',0):.2f}" for s in (sources or [])
     )
     line = (
-        f'"{ts}","{lang}","{clean(topic or "")}",'
+        f'"{ts}","{session_id}","{lang}","{clean(topic or "")}",'
         f'"{clean(q)}","{clean(a)}","{src_str}"\n'
     )
     if not log_path.exists():
         log_path.write_text(
-            '"timestamp","lang","topic","question","answer","sources"\n',
+            '"timestamp","session_id","lang","topic","question","answer","sources"\n',
             encoding="utf-8",
         )
     with log_path.open("a", encoding="utf-8") as f:
         f.write(line)
+    return session_id
 
 
 def extract_summary(answer: str) -> str:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -14,7 +14,20 @@ def test_append_log_writes_metadata(tmp_path: Path):
         lang="it",
         topic="neuro",
         sources=[{"id": "doc1", "score": 0.9}],
+        session_id="sess-1",
     )
     data = log.read_text(encoding="utf-8").strip().splitlines()
-    assert data[0] == '"timestamp","lang","topic","question","answer","sources"'
+    assert (
+        data[0]
+        == '"timestamp","session_id","lang","topic","question","answer","sources"'
+    )
     assert "doc1:0.90" in data[1]
+
+
+def test_append_log_includes_session_id(tmp_path: Path):
+    log = tmp_path / "log.csv"
+    sid = "sess-123"
+    append_log("q1", "a1", log, session_id=sid)
+    append_log("q2", "a2", log, session_id=sid)
+    lines = log.read_text(encoding="utf-8").strip().splitlines()[1:]
+    assert all(f'"{sid}"' in line for line in lines)


### PR DESCRIPTION
## Summary
- Include a session_id column in structured CSV logs, generating a uuid4 when one isn't provided.
- Propagate the current session_id from main.py when logging questions and answers.
- Test that log entries include the session_id and that the header reflects the new field.

## Testing
- `pytest tests/test_logging.py tests/test_structured_logging.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab370494248327b49c2fe748a54b3a