### PR TITLE
Fix duplicate session_id argument in main.py

### DIFF
--- a/OcchioOnniveggente/src/main.py
+++ b/OcchioOnniveggente/src/main.py
@@ -701,7 +701,6 @@ def main() -> None:
                     lang=pending_lang,
                     topic=pending_topic,
                     sources=pending_sources,
-                    session_id=session_id,
                 )
                 if pending_sources:
                     print("📚 Fonti:")


### PR DESCRIPTION
## Summary
- Fix startup crash by removing duplicate `session_id` keyword in `append_log`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab3bf1e7ac8327a28b302d615bd8cf