### PR TITLE
fix: define low_q before profile change detection

### DIFF
--- a/OcchioOnniveggente/src/main.py
+++ b/OcchioOnniveggente/src/main.py
@@ -540,6 +540,7 @@ def main() -> None:
                 say(f"📝 Domanda: {q}")
                 if not q:
                     continue
+                low_q = q.lower()
                 session_lang = update_language(session_lang, qlang, q)
                 eff_lang = session_lang
                 if PROF.contains_profanity(q):


### PR DESCRIPTION
## Summary
- fix missing low_q definition to prevent NameError when checking for profile changes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab3d17e9f883279db74f6717eb93f9