### PR TITLE
Handle structured realtime messages

### DIFF
--- a/OcchioOnniveggente/src/chat.py
+++ b/OcchioOnniveggente/src/chat.py
@@ -23,15 +23,16 @@ class ChatState:
         self.history.clear()
         self.summary = ""
 
-    def push_user(self, text: str) -> None:
-        self.history.append({"role": "user", "content": text})
+    def push_message(self, role: str, text: str) -> None:
+        self.history.append({"role": role, "content": text})
         self._trim()
-        self._persist("user", text)
+        self._persist(role, text)
+
+    def push_user(self, text: str) -> None:
+        self.push_message("user", text)
 
     def push_assistant(self, text: str) -> None:
-        self.history.append({"role": "assistant", "content": text})
-        self._trim()
-        self._persist("assistant", text)
+        self.push_message("assistant", text)
 
     def pin_message(self, text: str) -> None:
         if not text:

--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -1903,7 +1903,26 @@ class OracoloUI(tk.Tk):
                     break
                 time.sleep(0.05)
                 continue
-            self.after(0, lambda line=line: self._append_log(line, "LLM"))
+            text = line.rstrip("\n")
+            try:
+                data = json.loads(text)
+                text = str(data.get("text", ""))
+            except Exception:
+                pass
+            self.after(
+                0,
+                lambda t=text: self._append_log(
+                    t + ("\n" if not t.endswith("\n") else ""), "LLM"
+                ),
+            )
+            if text.startswith("…"):
+                msg = text.lstrip("…").strip()
+                self.chat_state.push_user(msg)
+                self.after(0, lambda m=msg: self._append_chat("user", m))
+            elif text.startswith("🔮"):
+                msg = text.lstrip("🔮").strip()
+                self.chat_state.push_assistant(msg)
+                self.after(0, lambda m=msg: self._append_chat("assistant", m))
         rest = f.read()
         if rest:
             self.after(0, lambda rest=rest: self._append_log(rest, "LLM"))


### PR DESCRIPTION
## Summary
- emit structured JSON logs from realtime_oracolo instead of prints
- parse and route structured output in UI, recording chat roles
- add generic ChatState.push_message for consistent history tracking

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab3e2d784c832791ba3a7aef84c563