### PR TITLE
Centralize OpenAI API key loading

### DIFF
--- a/OcchioOnniveggente/scripts/realtime_server.py
+++ b/OcchioOnniveggente/scripts/realtime_server.py
@@ -15,7 +15,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from src.config import Settings
+from src.config import Settings, get_openai_api_key
 from src.hotword import strip_hotword_prefix
 from src.oracle import transcribe, oracle_answer
 from src.chat import ChatState
@@ -412,7 +412,8 @@ main
 
         from openai import OpenAI
         load_dotenv()
-        client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+        api_key = get_openai_api_key(self.SET)
+        client = OpenAI(api_key=api_key) if api_key else OpenAI()
 
         text, lang = transcribe(
             audio_bytes, client, self.SET.openai.stt_model, debug=self.SET.debug

--- a/OcchioOnniveggente/src/main.py
+++ b/OcchioOnniveggente/src/main.py
@@ -19,7 +19,7 @@ from dotenv import load_dotenv
 from openai import OpenAI
 from pydantic import ValidationError
 
-from src.config import Settings
+from src.config import Settings, get_openai_api_key
 from src.filters import ProfanityFilter
 from src.audio import record_until_silence, play_and_pulse
 from src.lights import SacnLight, WledLight, color_from_text
@@ -210,7 +210,7 @@ def main() -> None:
         raw_settings = {}
         SET = Settings()
 
-    api_key = os.environ.get("OPENAI_API_KEY") or getattr(SET.openai, "api_key", "")
+    api_key = get_openai_api_key(SET)
     client = OpenAI(api_key=api_key) if api_key else OpenAI()
 
     session_profile_name, _ = get_active_profile(raw_settings)

--- a/OcchioOnniveggente/src/realtime_ws.py
+++ b/OcchioOnniveggente/src/realtime_ws.py
@@ -6,15 +6,17 @@ Non è integrato nel main loop; usalo per prove e poi lo innestiamo.
 import asyncio, json, os, sys, wave
 import websockets
 
-OPENAI_KEY = os.getenv("OPENAI_API_KEY")
+from src.config import get_openai_api_key
+
 REALTIME_MODEL = os.getenv("REALTIME_MODEL", "gpt-4o-realtime-preview")
 WS_URL = f"wss://api.openai.com/v1/realtime?model={REALTIME_MODEL}"
 
-async def run():
+
+async def run(api_key: str):
     async with websockets.connect(
         WS_URL,
         extra_headers={
-            "Authorization": f"Bearer {OPENAI_KEY}",
+            "Authorization": f"Bearer {api_key}",
             "OpenAI-Beta": "realtime=v1",
         },
         max_size=10_000_000,
@@ -27,8 +29,10 @@ async def run():
             msg = await ws.recv()
             print(msg)
 
+
 if __name__ == "__main__":
-    if not OPENAI_KEY:
+    api_key = get_openai_api_key()
+    if not api_key:
         print("⚠️ Set OPENAI_API_KEY first.")
         sys.exit(1)
-    asyncio.run(run())
+    asyncio.run(run(api_key))

--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -30,6 +30,7 @@ from src.retrieval import retrieve
 from src.chat import ChatState
 from src.oracle import oracle_answer, synthesize
 from src.domain import validate_question
+from src.config import get_openai_api_key
 
 import asyncio
 import numpy as np
@@ -832,14 +833,13 @@ class OracoloUI(tk.Tk):
         self.last_sources = []
         try:
             openai_conf = self.settings.get("openai", {})
-            api_key = openai_conf.get("api_key") or os.environ.get("OPENAI_API_KEY")
+            api_key = get_openai_api_key(self.settings)
             if not api_key:
                 if messagebox.askyesno(
                     "OpenAI", "È necessaria una API key OpenAI. Aprire le impostazioni?"
                 ):
                     self._open_openai_dialog()
-                    openai_conf = self.settings.get("openai", {})
-                    api_key = openai_conf.get("api_key") or os.environ.get("OPENAI_API_KEY")
+                    api_key = get_openai_api_key(self.settings)
                 if not api_key:
                     self.chat_entry.configure(state="disabled")
                     return
@@ -951,7 +951,7 @@ class OracoloUI(tk.Tk):
             return
         try:
             openai_conf = self.settings.get("openai", {})
-            api_key = openai_conf.get("api_key") or os.environ.get("OPENAI_API_KEY")
+            api_key = get_openai_api_key(self.settings)
             client = OpenAI(api_key=api_key) if api_key else OpenAI()
             tts_model = openai_conf.get("tts_model", "gpt-4o-mini-tts")
             tts_voice = openai_conf.get("tts_voice", "alloy")
@@ -1072,7 +1072,7 @@ class OracoloUI(tk.Tk):
             start = time.time()
             try:
                 openai_conf = self.settings.get("openai", {})
-                api_key = openai_conf.get("api_key") or os.environ.get("OPENAI_API_KEY")
+                api_key = get_openai_api_key(self.settings)
                 client = OpenAI(api_key=api_key) if api_key else OpenAI()
             except Exception:
                 client = None
@@ -1181,7 +1181,7 @@ class OracoloUI(tk.Tk):
         win.title("Limiti OpenAI")
         try:
             openai_conf = self.settings.get("openai", {})
-            api_key = openai_conf.get("api_key") or os.environ.get("OPENAI_API_KEY")
+            api_key = get_openai_api_key(self.settings)
             client = OpenAI(api_key=api_key) if api_key else OpenAI()
             model = self.settings.get("llm_model", "gpt-4o")
             info = client.models.retrieve(model)


### PR DESCRIPTION
## Summary
- add `get_openai_api_key` helper to load the OpenAI API key from environment or settings once
- refactor UI chat, realtime WebSocket helper and other modules to reuse the shared loader
- ensure realtime scripts and server pass the API key via parameters for consistency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab4239a1608327abf8d8913f2e3aa7