### PR TITLE
Expose dialogue deadline in ConversationManager

### DIFF
--- a/OcchioOnniveggente/src/conversation.py
+++ b/OcchioOnniveggente/src/conversation.py
@@ -36,6 +36,15 @@ class ConversationManager:
     def refresh_deadline(self) -> None:
         self.dlg.refresh_deadline()
 
+    @property
+    def active_deadline(self) -> float:
+        """Proxy access to the underlying dialogue deadline."""
+        return self.dlg.active_deadline
+
+    @active_deadline.setter
+    def active_deadline(self, value: float) -> None:
+        self.dlg.active_deadline = value
+
     def transition(self, new_state: DialogState) -> None:
         self.dlg.transition(new_state)
 


### PR DESCRIPTION
## Summary
- fix `AttributeError: 'ConversationManager' object has no attribute 'active_deadline'`
- expose `active_deadline` property to delegate to internal `DialogueManager`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab4476fc60832784e66a84f6f8ce0a