### PR TITLE
feat: relax domain threshold when context missing

### DIFF
--- a/OcchioOnniveggente/settings.yaml
+++ b/OcchioOnniveggente/settings.yaml
@@ -117,6 +117,7 @@ domain:
   accept_threshold: 0.75  # soglia più severa
   profile: "museo"        # profilo scelto dalla UI
   accept_threshold: 0.75  # soglia più severa per accettare la domanda
+  fallback_accept_threshold: 0.4  # usa questa soglia se emb_sim e RAG non danno risultati ma c'è una keyword
   clarify_margin: 0.10
   weights: { kw: 0.7, emb: 0.15, rag: 0.15 }
   always_accept_wake: true   # accetta sempre saluti/hotword

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1,0 +1,20 @@
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "OcchioOnniveggente"))
+from src.domain import validate_question
+
+
+def test_accept_keyword_without_embeddings_or_rag():
+    dom = SimpleNamespace(
+        enabled=True,
+        keywords=["museo"],
+        accept_threshold=0.75,
+        fallback_accept_threshold=0.4,
+    )
+    settings = SimpleNamespace(domain=dom)
+    ok, ctx, clarify, reason, sugg = validate_question("museo", settings=settings)
+    assert ok
+    thr = float(reason.split("thr=")[1].split()[0])
+    assert thr <= 0.4


### PR DESCRIPTION
## Summary
- allow domain validator to relax threshold when embeddings and RAG return nothing but keywords match
- document fallback threshold behaviour in settings
- test acceptance of keyword questions without embeddings or docstore

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab4f276d2483278786880b9daf000a