### PR TITLE
Log document ingestion outputs

### DIFF
--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -479,7 +479,10 @@ class OracoloUI(tk.Tk):
 
         # sandbox and log state
         self.sandbox_var = tk.BooleanVar(value=False)
-        self.log_filters = {c: tk.BooleanVar(value=True) for c in ["STT", "LLM", "TTS", "WS", "DOMAIN"]}
+        self.log_filters = {
+            c: tk.BooleanVar(value=True)
+            for c in ["STT", "LLM", "TTS", "WS", "DOMAIN", "DOCS"]
+        }
         self.log_entries: list[tuple[str, str]] = []
 
         self.profile_cb: ttk.Combobox | None = None
@@ -1275,14 +1278,25 @@ class OracoloUI(tk.Tk):
         if not script:
             messagebox.showwarning("Documento", "Script di ingest non trovato (scripts/ingest_docs.py).")
             return
+        self._append_log("Aggiunta documenti:\n" + "\n".join(paths) + "\n", "DOCS")
         try:
-            subprocess.run(
+            proc = subprocess.run(
                 [sys.executable, "-m", "scripts.ingest_docs", "--add", *paths],
                 check=True,
                 cwd=self.root_dir,
+                capture_output=True,
+                text=True,
             )
+            self._append_log(proc.stdout, "DOCS")
+            if proc.stderr:
+                self._append_log(proc.stderr, "DOCS")
             messagebox.showinfo("Successo", "Documenti aggiunti.")
         except subprocess.CalledProcessError as exc:
+            if exc.stdout:
+                self._append_log(exc.stdout, "DOCS")
+            if exc.stderr:
+                self._append_log(exc.stderr, "DOCS")
+            self._append_log(str(exc) + "\n", "DOCS")
             messagebox.showerror("Errore", f"Ingest fallito: {exc}")
 
     def _remove_documents(self) -> None:
@@ -1297,14 +1311,25 @@ class OracoloUI(tk.Tk):
         if not script:
             messagebox.showwarning("Documento", "Script di ingest non trovato (scripts/ingest_docs.py).")
             return
+        self._append_log("Rimozione documenti:\n" + "\n".join(paths) + "\n", "DOCS")
         try:
-            subprocess.run(
+            proc = subprocess.run(
                 [sys.executable, "-m", "scripts.ingest_docs", "--remove", *paths],
                 check=True,
                 cwd=self.root_dir,
+                capture_output=True,
+                text=True,
             )
+            self._append_log(proc.stdout, "DOCS")
+            if proc.stderr:
+                self._append_log(proc.stderr, "DOCS")
             messagebox.showinfo("Successo", "Documenti rimossi.")
         except subprocess.CalledProcessError as exc:
+            if exc.stdout:
+                self._append_log(exc.stdout, "DOCS")
+            if exc.stderr:
+                self._append_log(exc.stderr, "DOCS")
+            self._append_log(str(exc) + "\n", "DOCS")
             messagebox.showerror("Errore", f"Rimozione fallita: {exc}")
 
     def _reindex_documents(self) -> None:
@@ -1314,15 +1339,29 @@ class OracoloUI(tk.Tk):
             return
         tried = (["--reindex"], ["--rebuild"], ["--refresh"])
         for args in tried:
+            self._append_log(
+                f"Aggiorna indice: {' '.join(args)} in {self.root_dir}\n",
+                "DOCS",
+            )
             try:
-                subprocess.run(
+                proc = subprocess.run(
                     [sys.executable, "-m", "scripts.ingest_docs", *args],
                     check=True,
                     cwd=self.root_dir,
+                    capture_output=True,
+                    text=True,
                 )
+                self._append_log(proc.stdout, "DOCS")
+                if proc.stderr:
+                    self._append_log(proc.stderr, "DOCS")
                 messagebox.showinfo("Indice", f"Indice aggiornato ({' '.join(args)}).")
                 return
-            except subprocess.CalledProcessError:
+            except subprocess.CalledProcessError as exc:
+                if exc.stdout:
+                    self._append_log(exc.stdout, "DOCS")
+                if exc.stderr:
+                    self._append_log(exc.stderr, "DOCS")
+                self._append_log(str(exc) + "\n", "DOCS")
                 continue
         messagebox.showerror("Indice", "Impossibile aggiornare l'indice (nessuna delle opzioni supportata).")
 


### PR DESCRIPTION
## Summary
- capture stdout/stderr from document ingestion scripts and log them under a new `DOCS` category
- log document paths before adding/removing and report errors to the log on failure
- allow filtering document logs via a new `DOCS` checkbox in the UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab50f5d12c8327aaaf66677c152d23