### PR TITLE
Fix idle status update indentation

### DIFF
--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -1058,7 +1058,7 @@ class OracoloUI(tk.Tk):
         if now - self.last_activity > timeout:
             self.status_var.set("😴 Dormiente — dì Ciao Oracolo per riattivarmi")
         elif self.status_var.get().startswith("😴"):
-        self.status_var.set("🟡 In attesa")
+            self.status_var.set("🟡 In attesa")
         self.after(1000, self._poll_idle)
 
     # --------------------------- Log helpers ------------------------------ #


### PR DESCRIPTION
## Summary
- correct indentation in `_poll_idle` to restore status updates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab52f4bf3c832798ebd22762c847d2