### PR TITLE
Log wake configuration and hotword detection

### DIFF
--- a/OcchioOnniveggente/src/main.py
+++ b/OcchioOnniveggente/src/main.py
@@ -18,6 +18,7 @@ import yaml
 from dotenv import load_dotenv
 from openai import OpenAI
 from pydantic import ValidationError
+import logging
 
 from src.config import Settings, get_openai_api_key
 from src.filters import ProfanityFilter
@@ -442,9 +443,11 @@ def main() -> None:
                     if wake:
                         text = text_en
                 say(f"📝 Riconosciuto: {text}")
+                logging.info("Hotword riconosciuta: %s (lang=%s)", text, lang)
                 if not wake:
                     if DEBUG:
                         say("…hotword non riconosciuta, continuo l'attesa.")
+                    logging.info("Hotword non riconosciuta: %s", text)
                     continue
                 session_lang = update_language(session_lang, lang, "")
                 wake_lang = session_lang or lang or "it"
@@ -470,9 +473,13 @@ def main() -> None:
                         elif text_it:
                             session_lang = "it"
                 say(f"📝 Riconosciuto: {text}")
+                logging.info(
+                    "Hotword riconosciuta: %s (lang=%s)", text, session_lang
+                )
                 if not (is_it or is_en):
                     if DEBUG:
                         say("…hotword non riconosciuta, continuo l'attesa.")
+                    logging.info("Hotword non riconosciuta: %s", text)
                     continue
                 wake_lang = session_lang or ("en" if is_en and not is_it else "it")
 

--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -497,7 +497,7 @@ class OracoloUI(tk.Tk):
         self.sandbox_var = tk.BooleanVar(value=False)
         self.log_filters = {
             c: tk.BooleanVar(value=True)
-            for c in ["STT", "LLM", "TTS", "WS", "DOMAIN", "DOCS"]
+            for c in ["STT", "LLM", "TTS", "WS", "DOMAIN", "DOCS", "WAKE"]
         }
         self.log_entries: list[tuple[str, str]] = []
 
@@ -1833,8 +1833,8 @@ class OracoloUI(tk.Tk):
             wake["it_phrases"] = [p.strip() for p in it_var.get().split(",") if p.strip()]
             wake["en_phrases"] = [p.strip() for p in en_var.get().split(",") if p.strip()]
             self._append_log(
-                f"Wake: timeout={wake['idle_timeout']} it={wake['it_phrases']} en={wake['en_phrases']}\n",
-                "MISC",
+                f"Wake timeout={timeout_var.get()} IT={it_var.get()} EN={en_var.get()}",
+                "WAKE",
             )
             win.destroy()
 


### PR DESCRIPTION
## Summary
- log wake dialog settings under a dedicated WAKE category
- record hotword detection and failures using Python logging

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab5298d9c48327a0f2e0f4ddf79e3b