### PR TITLE
Improve keyword overlap scoring and short question handling

### DIFF
--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -18,3 +18,15 @@ def test_accept_keyword_without_embeddings_or_rag():
     assert ok
     thr = float(reason.split("thr=")[1].split()[0])
     assert thr <= 0.4
+
+
+def test_short_question_with_keyword():
+    dom = SimpleNamespace(
+        enabled=True,
+        keywords=["arte"],
+        accept_threshold=0.75,
+        fallback_accept_threshold=0.4,
+    )
+    settings = SimpleNamespace(domain=dom)
+    ok, ctx, clarify, reason, sugg = validate_question("mi parli di arte?", settings=settings)
+    assert ok


### PR DESCRIPTION
## Summary
- Normalize keyword overlap score by the smaller token set to handle short or long queries fairly
- Lower acceptance threshold slightly for short questions that contain domain keywords
- Add test ensuring a short query like "mi parli di arte?" is accepted

## Testing
- `pytest tests/test_domain.py tests/test_validator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab594e624883279777baca99887a96