### PR TITLE
Avoid duplicate hotword logs

### DIFF
--- a/OcchioOnniveggente/src/main.py
+++ b/OcchioOnniveggente/src/main.py
@@ -442,8 +442,6 @@ def main() -> None:
                     wake, lang = is_wake(text_en, WAKE_IT, WAKE_EN)
                     if wake:
                         text = text_en
-                say(f"📝 Riconosciuto: {text}")
-                logging.info("Hotword riconosciuta: %s (lang=%s)", text, lang)
                 if not wake:
                     if DEBUG:
                         say("…hotword non riconosciuta, continuo l'attesa.")


### PR DESCRIPTION
## Summary
- prevent duplicate 'Hotword riconosciuta' logging in hotword listener

## Testing
- `pytest`
- manual simulation of hotword detection to confirm single log pair

------
https://chatgpt.com/codex/tasks/task_e_68ab594eadc08327875aa04fc165c6fb