### PR TITLE
feat: suggest topics for off-theme questions

### DIFF
--- a/OcchioOnniveggente/scripts/realtime_server.py
+++ b/OcchioOnniveggente/scripts/realtime_server.py
@@ -99,6 +99,20 @@ def write_wav(path: Path, sr: int, pcm: bytes) -> None:
         w.writeframes(pcm)
 
 
+def off_topic_message(profile: str, keywords: list[str]) -> str:
+    """Compose a helpful message when the question is off-topic."""
+    tips = ", ".join(keywords[:3]) if keywords else ""
+    if tips:
+        return (
+            f"La domanda non sembra pertinente rispetto al profilo «{profile}». "
+            f"Puoi chiedermi, ad esempio, di {tips}."
+        )
+    return (
+        f"La domanda non sembra pertinente rispetto al profilo «{profile}». "
+        "Prova a riformularla o a specificare meglio il tema."
+    )
+
+
 async def stream_tts_pcm(
     ws, client, text: str, tts_model: str, tts_voice: str, sr: int = 24000
 ) -> None:
@@ -360,7 +374,7 @@ class RTSession:
             if clarify:
                 ans = "La domanda non è chiarissima per questo contesto: puoi riformularla brevemente?"
             else:
-                ans = f"Tema non pertinente rispetto al profilo «{self.profile}»."
+                ans = off_topic_message(self.profile, self.domain_keywords)
             await self.send_answer(ans)
             await self.stream_sentences(ans, client)
             return

--- a/tests/test_realtime_server.py
+++ b/tests/test_realtime_server.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "OcchioOnniveggente"))
+from scripts.realtime_server import off_topic_message
+
+
+def test_off_topic_message_with_keywords():
+    msg = off_topic_message("museo", ["arte", "storia", "scienza"])
+    assert "profilo «museo»" in msg
+    assert "arte, storia, scienza" in msg
+
+
+def test_off_topic_message_without_keywords():
+    msg = off_topic_message("museo", [])
+    assert "profilo «museo»" in msg
+    assert "riformularla" in msg.lower()


### PR DESCRIPTION
## Summary
- provide helpful off-topic message with keyword suggestions
- add unit tests for new off-topic helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab59508140832788eb3c501653deb2