### PR TITLE
Handle RAG hits when validating questions

### DIFF
--- a/OcchioOnniveggente/src/domain.py
+++ b/OcchioOnniveggente/src/domain.py
@@ -410,13 +410,14 @@ def validate_question(
     reason = f"kw={kw_score:.2f} emb={emb_sim:.2f} rag={rag_score:.2f} score={score:.2f} thr={thr:.2f}"
 
     topic_suggestion = ""
-    # Se non c'è alcuna parola-chiave e non ci sono boost terms,
-    # la domanda è considerata fuori dominio anche se il punteggio totale supera la soglia.
-    if kw_score == 0 and not has_boost:
+    # Se non c'è alcuna parola-chiave e non ci sono boost terms
+    # e il retrieval non ha restituito alcun risultato, la domanda
+    # è considerata fuori dominio anche se il punteggio totale supera la soglia.
+    if kw_score == 0 and rag_hits == 0 and not has_boost:
         ok = False
         clarify = score >= (thr - clarify_margin)
         ctx = []
-        reason += " kw0"
+        reason += f" kw0 rag_hits={rag_hits}"
     if clarify and docstore_path:
         try:
             alt_ctx = _try_retrieve(

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -65,3 +65,27 @@ def test_off_topic_rejected():
     assert not ok
     assert not clarify
     assert ctx == []
+    assert "rag_hits=0" in reason
+
+
+def test_rag_hits_allow_without_keywords(tmp_path):
+    index = tmp_path / "index.json"
+    data = {
+        "documents": [
+            {"id": "1", "text": "Cats are animals", "topic": "animals"},
+        ]
+    }
+    index.write_text(json.dumps(data), encoding="utf-8")
+
+    dom = SimpleNamespace(
+        enabled=True,
+        keywords=["football"],
+        accept_threshold=0.1,
+        weights={"kw": 0.0, "emb": 0.0, "rag": 1.0},
+    )
+    settings = SimpleNamespace(domain=dom)
+    ok, ctx, clarify, reason, sugg = validate_question(
+        "Cats", settings=settings, docstore_path=index, top_k=1
+    )
+    assert ok
+    assert ctx


### PR DESCRIPTION
## Summary
- Avoid rejecting questions with RAG results even if no keywords match
- Log RAG hit count when rejecting off-topic queries
- Add tests for RAG-based acceptance and reason reporting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab66b4591c8327bcc4f1d9fb87a005