### PR TITLE
Add domain profiles for THEM, CryptoMadonne and Adriano Lombardo

### DIFF
--- a/OcchioOnniveggente/settings.yaml
+++ b/OcchioOnniveggente/settings.yaml
@@ -113,7 +113,7 @@ wake:
 domain:
   enabled: true
 
-  profile: "museo"        # scelto dalla UI (museo | conferenze | gallerie | didattica)
+  profile: "museo"        # scelto dalla UI (museo | conferenze | gallerie | didattica | them | cryptomadonne | adriano_lombardo)
   accept_threshold: 0.75  # soglia più severa
   profile: "museo"        # profilo scelto dalla UI
   accept_threshold: 0.75  # soglia più severa per accettare la domanda
@@ -184,6 +184,42 @@ domain:
         - valutazione
       docstore_path: "DataBase/didattica/index.json"
       system_hint: "Spiega in modo chiaro, con esempi adatti a studenti."
+      retrieval_top_k: 4
+
+    them:
+
+      label: "Them"
+      keywords:
+        - them
+        - identità
+        - collettivo
+        - futuro
+      docstore_path: "DataBase/them/index.json"
+      system_hint: "Rispondi come curatore del progetto THEM su identità e collettività."
+      retrieval_top_k: 4
+
+    cryptomadonne:
+
+      label: "CryptoMadonne"
+      keywords:
+        - nft
+        - criptoarte
+        - madonne
+        - blockchain
+      docstore_path: "DataBase/cryptomadonne/index.json"
+      system_hint: "Rispondi come esperto di cripto-arte legata alle Madonne."
+      retrieval_top_k: 4
+
+    adriano_lombardo:
+
+      label: "Adriano Lombardo"
+      keywords:
+        - adriano lombardo
+        - installazione
+        - scultura
+        - concettuale
+      docstore_path: "DataBase/adriano_lombardo/index.json"
+      system_hint: "Rispondi come l'artista Adriano Lombardo, con riferimenti a installazioni e sculture concettuali."
       retrieval_top_k: 4
 
 retrieval:

--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -1507,7 +1507,7 @@ class OracoloUI(tk.Tk):
         ttk.Button(win, text="Sfoglia", command=browse).grid(row=0, column=2, padx=6, pady=6)
 
         tk.Label(win, text="Sezione", fg=self._fg, bg=self._bg).grid(row=1, column=0, padx=6, pady=6, sticky="e")
-        tk.OptionMenu(win, topic_var, topic_var.get(), "gallerie", "museo", "conferenze", "didattica").grid(
+        tk.OptionMenu(win, topic_var, topic_var.get(), "gallerie", "museo", "conferenze", "didattica", "them", "cryptomadonne", "adriano_lombardo").grid(
             row=1, column=1, padx=6, pady=6, sticky="w"
         )
 


### PR DESCRIPTION
## Summary
- add THEM, CryptoMadonne and Adriano Lombardo domain profiles with keywords, docstore paths and hints
- allow selecting the new profiles from the document manager UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab698ef984832799593e5795e52b94