### PR TITLE
Fix profile-based document association

### DIFF
--- a/OcchioOnniveggente/settings.yaml
+++ b/OcchioOnniveggente/settings.yaml
@@ -114,8 +114,6 @@ domain:
   enabled: true
 
   profile: "museo"        # scelto dalla UI (museo | conferenze | gallerie | didattica | them | cryptomadonne | adriano_lombardo)
-  accept_threshold: 0.75  # soglia più severa
-  profile: "museo"        # profilo scelto dalla UI
   accept_threshold: 0.75  # soglia più severa per accettare la domanda
   fallback_accept_threshold: 0.4  # usa questa soglia se emb_sim e RAG non danno risultati ma c'è una keyword
   clarify_margin: 0.10

--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -1515,8 +1515,6 @@ class OracoloUI(tk.Tk):
         tk.Label(win, text="Sezione", fg=self._fg, bg=self._bg).grid(row=1, column=0, padx=6, pady=6, sticky="e")
         opts = [p for p in self.profile_names if p != current_profile]
         tk.OptionMenu(win, topic_var, current_profile, *opts).grid(
-        tk.OptionMenu(win, topic_var, topic_var.get(), "gallerie", "museo", "conferenze", "didattica", "them", "cryptomadonne", "adriano_lombardo").grid(
-
             row=1, column=1, padx=6, pady=6, sticky="w"
         )
 


### PR DESCRIPTION
## Summary
- Clean up domain profile block in settings to ensure profiles parse correctly
- Use dynamic profile list in document manager so documents attach to the active oracle profile

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab5e305fb4832780b0dec2817219b1