### PR TITLE
Fix domain config duplication and add serialization tests

### DIFF
--- a/OcchioOnniveggente/README.md
+++ b/OcchioOnniveggente/README.md
@@ -30,6 +30,14 @@ openai:
   stt_model: gpt-4o-mini-transcribe
 ```
 
+Per limitare le risposte a un determinato contesto è possibile definire un profilo di dominio:
+
+```yaml
+domain:
+  profile: "museo"  # profilo selezionato
+  topic: ""        # contesto specifico opzionale
+```
+
 Se ad esempio `audio.sample_rate` contiene una stringa (`"ventiquattromila"`) invece di un
 numero, Pydantic segnalerà `Input should be a valid integer` e userà `24000`.
 

--- a/OcchioOnniveggente/settings.yaml
+++ b/OcchioOnniveggente/settings.yaml
@@ -112,8 +112,8 @@ wake:
 # ⬇️ NUOVO: impostazioni per RAG/pertinenza dominio
 domain:
   enabled: true
-
   profile: "museo"        # scelto dalla UI (museo | conferenze | gallerie | didattica | them | cryptomadonne | adriano_lombardo)
+  topic: ""              # contesto specifico opzionale
   accept_threshold: 0.75  # soglia più severa per accettare la domanda
   fallback_accept_threshold: 0.4  # usa questa soglia se emb_sim e RAG non danno risultati ma c'è una keyword
   clarify_margin: 0.10

--- a/OcchioOnniveggente/src/config.py
+++ b/OcchioOnniveggente/src/config.py
@@ -93,7 +93,6 @@ class DomainConfig(BaseModel):
     enabled: bool = True
     profile: str = "museo"
     topic: str = ""
-    profile: str = ""
     keywords: List[str] = Field(default_factory=list)
     kw_min_overlap: float = 0.04
     emb_min_sim: float = 0.22

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,8 @@
 import sys
 from pathlib import Path
+
 import pytest
+import yaml
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from OcchioOnniveggente.src.config import Settings
@@ -18,3 +20,13 @@ def test_model_validate_yaml_valid_yaml(tmp_path: Path) -> None:
     good.write_text("debug: true", encoding="utf-8")
     settings = Settings.model_validate_yaml(good)
     assert settings.debug is True
+
+
+def test_round_trip_defaults(tmp_path: Path) -> None:
+    original = Settings()
+    path = tmp_path / "settings.yaml"
+    path.write_text(yaml.safe_dump(original.model_dump()), encoding="utf-8")
+    loaded = Settings.model_validate_yaml(path)
+    assert loaded == original
+    assert loaded.domain.profile == "museo"
+    assert loaded.domain.topic == ""


### PR DESCRIPTION
## Summary
- remove duplicate `profile` field in `DomainConfig` and expose optional `topic`
- document new `topic` field in README and default settings
- add round-trip test to ensure settings serialization preserves defaults

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab739e8c5c832799aeb1bca08abdde