### PR TITLE
Refine profile handling and domain settings generation

### DIFF
--- a/OcchioOnniveggente/src/main.py
+++ b/OcchioOnniveggente/src/main.py
@@ -109,64 +109,54 @@ def oracle_greeting(lang: str) -> str:
 
 
 def get_active_profile(SETTINGS, forced_name: str | None = None):
+    """Return the active profile name and configuration."""
     if isinstance(SETTINGS, dict):
-
         dom = SETTINGS.get("domain", {}) or {}
-        prof_name = dom.get("profile", "museo")
-        dom = SETTINGS.get("domain") or {}
         prof_name = forced_name or dom.get("profile", "museo")
         profiles = dom.get("profiles", {}) or {}
-        prof = profiles.get(prof_name, {})
     else:
         dom = getattr(SETTINGS, "domain", None)
-        prof_name = getattr(dom, "profile", "museo") if dom else "museo"
+        prof_name = forced_name or (
+            getattr(dom, "profile", "museo") if dom else "museo"
+        )
         profiles = getattr(dom, "profiles", {}) if dom else {}
-        prof_name = forced_name or getattr(dom, "profile", "museo")
-        profiles = getattr(dom, "profiles", {}) or {}
-        prof = profiles.get(prof_name, {})
+    prof = profiles.get(prof_name, {})
     return prof_name, prof
 
 
-
-def make_domain_settings(base_settings, prof_name):
-    if isinstance(base_settings, dict):
-        new_s = dict(base_settings)
-        dom = dict(new_s.get("domain") or {})
-        dom["enabled"] = True
-        dom["profile"] = prof_name
-
 def make_domain_settings(base_settings, prof_name: str, prof):
+    """Return ``base_settings`` with domain info replaced by ``prof``."""
     if isinstance(base_settings, dict):
         new_s = dict(base_settings)
         dom = dict(new_s.get("domain", {}))
-        dom.update({
-            "enabled": True,
-            "profile": prof.get("topic", ""),
-            "profile": prof_name,
-            "keywords": prof.get("keywords", []),
-        })
+        dom.update(
+            {
+                "enabled": True,
+                "profile": prof_name,
+                "topic": prof.get("topic", ""),
+                "keywords": prof.get("keywords", []),
+            }
+        )
         if prof.get("weights"):
-            dom["weights"] = prof.get("weights")
+            dom["weights"] = prof["weights"]
         if prof.get("accept_threshold") is not None:
-            dom["accept_threshold"] = prof.get("accept_threshold")
+            dom["accept_threshold"] = prof["accept_threshold"]
         if prof.get("clarify_margin") is not None:
-            dom["clarify_margin"] = prof.get("clarify_margin")
-
+            dom["clarify_margin"] = prof["clarify_margin"]
         new_s["domain"] = dom
         return new_s
     else:
         try:
             base_settings.domain.enabled = True
-            base_settings.domain.profile = prof.get("topic", "")
             base_settings.domain.profile = prof_name
+            base_settings.domain.topic = prof.get("topic", "")
             base_settings.domain.keywords = prof.get("keywords", [])
             if prof.get("weights"):
-                base_settings.domain.weights = prof.get("weights")
+                base_settings.domain.weights = prof["weights"]
             if prof.get("accept_threshold") is not None:
-                base_settings.domain.accept_threshold = prof.get("accept_threshold")
+                base_settings.domain.accept_threshold = prof["accept_threshold"]
             if prof.get("clarify_margin") is not None:
-                base_settings.domain.clarify_margin = prof.get("clarify_margin")
-
+                base_settings.domain.clarify_margin = prof["clarify_margin"]
         except Exception:
             pass
         return base_settings

--- a/tests/test_profile_domain_settings.py
+++ b/tests/test_profile_domain_settings.py
@@ -1,0 +1,52 @@
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# ``main`` imports ``sounddevice`` which requires PortAudio; mock it to avoid ImportError.
+sys.modules.setdefault("sounddevice", MagicMock())
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "OcchioOnniveggente"))
+from OcchioOnniveggente.src.main import get_active_profile, make_domain_settings
+
+
+def test_get_active_profile_selects_profile():
+    settings = {
+        "domain": {
+            "profile": "museo",
+            "profiles": {
+                "museo": {"topic": "museo", "keywords": ["arte"]},
+                "science": {"topic": "science", "keywords": ["fisica"]},
+            },
+        }
+    }
+    name, prof = get_active_profile(settings)
+    assert name == "museo" and prof.get("topic") == "museo"
+    name, prof = get_active_profile(settings, forced_name="science")
+    assert name == "science" and prof.get("topic") == "science"
+
+
+def test_make_domain_settings_generates_domain_dict():
+    base = {}
+    prof_name = "science"
+    prof = {"topic": "physics", "keywords": ["fisica", "chimica"], "weights": {"a": 1}}
+    new_set = make_domain_settings(base, prof_name, prof)
+    domain = new_set["domain"]
+    assert domain["enabled"] is True
+    assert domain["profile"] == prof_name
+    assert domain["topic"] == "physics"
+    assert domain["keywords"] == ["fisica", "chimica"]
+    assert domain["weights"] == {"a": 1}
+
+
+def test_make_domain_settings_accepts_namespace():
+    base = SimpleNamespace(domain=SimpleNamespace())
+    prof = {"topic": "history", "keywords": ["rome"]}
+    make_domain_settings(base, "hist-profile", prof)
+    dom = base.domain
+    assert dom.enabled is True
+    assert dom.profile == "hist-profile"
+    assert dom.topic == "history"
+    assert dom.keywords == ["rome"]


### PR DESCRIPTION
## Summary
- streamline profile selection by consolidating `get_active_profile`
- remove old incomplete `make_domain_settings` and ensure unique `profile`, `topic`, and `keywords`
- add tests covering profile selection and domain settings construction

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab739ed5b88327aba2dc80e3cafdfa