### PR TITLE
Refactor domain scoring and add unified settings helper

### DIFF
--- a/tests/test_context_compression.py
+++ b/tests/test_context_compression.py
@@ -1,10 +1,12 @@
 import json
 from pathlib import Path
 import sys
+from types import SimpleNamespace
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from OcchioOnniveggente.src.retrieval import retrieve, _simple_sentences
+from OcchioOnniveggente.src.domain import _get_field
 
 
 def test_retrieve_compresses_passages(tmp_path):
@@ -19,3 +21,10 @@ def test_retrieve_compresses_passages(tmp_path):
     res = retrieve("banana", p, top_k=1)
     assert len(_simple_sentences(res[0]["text"])) <= 5
     assert "banana" in res[0]["text"]
+
+
+def test_get_field_in_context_module():
+    obj = SimpleNamespace(x=1)
+    d = {"x": 2}
+    assert _get_field(obj, "x") == 1
+    assert _get_field(d, "x") == 2

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "OcchioOnniveggente"))
-from src.domain import validate_question
+from src.domain import validate_question, _get_field
 
 
 def test_accept_keyword_without_embeddings_or_rag():
@@ -29,4 +29,24 @@ def test_short_question_with_keyword():
     )
     settings = SimpleNamespace(domain=dom)
     ok, ctx, clarify, reason, sugg = validate_question("mi parli di arte?", settings=settings)
+    assert ok
+
+
+def test_get_field_works_with_dict_and_obj():
+    ns = SimpleNamespace(foo=1)
+    d = {"foo": 2}
+    assert _get_field(ns, "foo") == 1
+    assert _get_field(d, "foo") == 2
+    assert _get_field(d, "missing", 5) == 5
+
+
+def test_validate_with_dict_settings():
+    dom = {
+        "enabled": True,
+        "keywords": ["museo"],
+        "accept_threshold": 0.75,
+        "fallback_accept_threshold": 0.4,
+    }
+    settings = {"domain": dom}
+    ok, ctx, clarify, reason, sugg = validate_question("museo", settings=settings)
     assert ok


### PR DESCRIPTION
## Summary
- introduce `_get_field` for dict/Pydantic access
- split domain validation into config reading, scoring, and adaptive threshold helpers
- extend tests to cover new helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab739fe49883278036f1d21b9afb8d