### PR TITLE
feat: introduce UI controller for business logic

### DIFF
--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -12,7 +12,6 @@ UI Tkinter per Occhio Onniveggente.
 
 from __future__ import annotations
 
-import copy
 import json
 import csv
 import os
@@ -28,11 +27,10 @@ from tkinter import filedialog, messagebox, scrolledtext, simpledialog, ttk
 from typing import Any, Callable
 
 from src.retrieval import retrieve
-from src.chat import ChatState
-from src.conversation import ConversationManager
-from src.oracle import oracle_answer, synthesize
 from src.domain import validate_question
 from src.config import get_openai_api_key
+from src.oracle import synthesize
+from src.ui_controller import UiController, _REASON_RE
 
 import asyncio
 import numpy as np
@@ -57,10 +55,6 @@ except Exception:  # pragma: no cover - fallback se non disponibile
 WS_URL = os.getenv("ORACOLO_WS_URL", "ws://localhost:8765")
 SR = 24_000
 
-_REASON_RE = re.compile(
-    r"kw=(?P<kw>[-0-9.]+) emb=(?P<emb>[-0-9.]+) rag=(?P<rag>[-0-9.]+) score=(?P<score>[-0-9.]+) thr=(?P<thr>[-0-9.]+)"
-)
-
 
 def _highlight_terms(text: str, query: str) -> str:
     """Evidenzia i termini della query all'interno del testo."""
@@ -76,87 +70,6 @@ try:
 except Exception:
     Image = None
     ImageTk = None
-
-
-# ------------------------------ helpers ---------------------------------- #
-def deep_update(base: dict, upd: dict) -> dict:
-    for k, v in (upd or {}).items():
-        if isinstance(v, dict) and isinstance(base.get(k), dict):
-            deep_update(base[k], v)
-        else:
-            base[k] = v
-    return base
-
-
-def deep_copy(d: dict) -> dict:
-    return copy.deepcopy(d or {})
-
-
-def load_settings_pair(root: Path) -> tuple[dict, dict, dict]:
-    """Ritorna (base, local, merged)."""
-    base_p = root / "settings.yaml"
-    local_p = root / "settings.local.yaml"
-
-    base = {}
-    local = {}
-    if base_p.exists():
-        base = yaml.safe_load(base_p.read_text(encoding="utf-8")) or {}
-    if local_p.exists():
-        local = yaml.safe_load(local_p.read_text(encoding="utf-8")) or {}
-
-    merged = deep_copy(base)
-    merged = deep_update(merged, deep_copy(local))
-    return base, local, merged
-
-
-def routed_save(
-    base_now: dict,
-    local_now: dict,
-    merged_new: dict,
-    root: Path,
-    log_fn: Callable[[str, str], None] | None = None,
-) -> None:
-    """
-    Salva split:
-      - In settings.local.yaml: debug, audio.input_device, audio.output_device
-      - In settings.yaml: tutto il resto
-    Mantiene eventuali altre chiavi locali preesistenti.
-
-    Se ``log_fn`` è fornito, emette un log per ogni file aggiornato.
-    """
-    local_out = deep_copy(local_now)
-    local_out.setdefault("audio", {})
-    local_out["debug"] = bool(merged_new.get("debug", local_out.get("debug", False)))
-
-    audio_new = deep_copy(merged_new.get("audio", {}))
-    if "input_device" in audio_new:
-        local_out["audio"]["input_device"] = audio_new.get(
-            "input_device", local_out["audio"].get("input_device")
-        )
-    if "output_device" in audio_new:
-        local_out["audio"]["output_device"] = audio_new.get(
-            "output_device", local_out["audio"].get("output_device")
-        )
-
-    base_out = deep_copy(merged_new)
-    base_out.pop("debug", None)
-    if "audio" in base_out:
-        base_out["audio"].pop("input_device", None)
-        base_out["audio"].pop("output_device", None)
-
-    base_changed = base_out != base_now
-    local_changed = local_out != local_now
-
-    (root / "settings.yaml").write_text(
-        yaml.safe_dump(base_out, sort_keys=False, allow_unicode=True), encoding="utf-8"
-    )
-    if base_changed and log_fn is not None:
-        log_fn("Aggiornato settings.yaml\n", "MISC")
-    (root / "settings.local.yaml").write_text(
-        yaml.safe_dump(local_out, sort_keys=False, allow_unicode=True), encoding="utf-8"
-    )
-    if local_changed and log_fn is not None:
-        log_fn("Aggiornato settings.local.yaml\n", "MISC")
 
 
 # ------------------------- Realtime WS client ---------------------------- #
@@ -450,8 +363,13 @@ class OracoloUI(tk.Tk):
         style.configure("TLabel", background=self._bg, foreground=self._fg)
         style.configure("TFrame", background=self._bg)
 
-        # settings
-        self.base_settings, self.local_settings, self.settings = load_settings_pair(self.root_dir)
+        # settings and controller
+        self.controller = UiController(self.root_dir)
+        self.base_settings = self.controller.base_settings
+        self.local_settings = self.controller.local_settings
+        self.settings = self.controller.settings
+        self.conv = self.controller.conv
+        self.chat_state = self.controller.chat_state
 
         # quick toggles state
         self.lang_map = {"Auto": "auto", "IT": "it", "EN": "en"}
@@ -464,12 +382,6 @@ class OracoloUI(tk.Tk):
         self.style_var = tk.BooleanVar(value=True)
         self.use_mic_var = tk.BooleanVar(value=True)
         chat_conf = self.settings.get("chat", {})
-        self.conv = ConversationManager()
-        self.chat_state = self.conv.chat
-        self.chat_state.max_turns = int(chat_conf.get("max_turns", 10)) if chat_conf.get("enabled", True) else 0
-        pj = chat_conf.get("persist_jsonl")
-        if pj:
-            self.chat_state.persist_jsonl = Path(pj)
         self.remember_var = tk.BooleanVar(value=bool(chat_conf.get("enabled", True)))
         self.turns_var = tk.IntVar(value=int(chat_conf.get("max_turns", 10)))
         dom = self.settings.get("domain", {})
@@ -798,13 +710,10 @@ class OracoloUI(tk.Tk):
             self.keywords.append(kw)
             self.keyword_listbox.insert("end", kw)
             self.settings["keywords"] = self.keywords
-            routed_save(
-                self.base_settings,
-                self.local_settings,
-                self.settings,
-                self.root_dir,
-                self._append_log,
-            )
+            self.controller.save_settings(self._append_log)
+            self.base_settings = self.controller.base_settings
+            self.local_settings = self.controller.local_settings
+            self.settings = self.controller.settings
             self._append_log(f"Aggiunta keyword: {kw}", "DOMAIN")
         self.keyword_entry.delete(0, "end")
 
@@ -819,13 +728,10 @@ class OracoloUI(tk.Tk):
             removed = True
         if removed:
             self.settings["keywords"] = self.keywords
-            routed_save(
-                self.base_settings,
-                self.local_settings,
-                self.settings,
-                self.root_dir,
-                self._append_log,
-            )
+            self.controller.save_settings(self._append_log)
+            self.base_settings = self.controller.base_settings
+            self.local_settings = self.controller.local_settings
+            self.settings = self.controller.settings
 
     def _pin_last(self) -> None:
         self.chat_state.pin_last_user()
@@ -837,13 +743,10 @@ class OracoloUI(tk.Tk):
 
     def _apply_profile(self, name: str) -> None:
         self.settings.setdefault("domain", {})["profile"] = name
-        routed_save(
-            self.base_settings,
-            self.local_settings,
-            self.settings,
-            self.root_dir,
-            self._append_log,
-        )
+        self.controller.save_settings(self._append_log)
+        self.base_settings = self.controller.base_settings
+        self.local_settings = self.controller.local_settings
+        self.settings = self.controller.settings
         self._append_log(f"Profilo attivo: {name}", "DOMAIN")
         if self.ws_client is not None:
             self.ws_client.profile_name = name
@@ -904,88 +807,22 @@ class OracoloUI(tk.Tk):
         else:
             self._append_chat("system", "Comando sconosciuto")
 
+    
     def _send_chat(self, text: str) -> None:
         self.last_activity = time.time()
         self._append_chat("user", text)
-        self.conv.push_user(text)
-        self.last_sources = []
         try:
-            openai_conf = self.settings.get("openai", {})
-            api_key = get_openai_api_key(self.settings)
-            if not api_key:
-                if messagebox.askyesno(
-                    "OpenAI", "È necessaria una API key OpenAI. Aprire le impostazioni?"
-                ):
-                    self._open_openai_dialog()
-                    api_key = get_openai_api_key(self.settings)
-                if not api_key:
-                    self.chat_entry.configure(state="disabled")
-                    return
-                else:
-                    self.chat_entry.configure(state="normal")
-            client = OpenAI(api_key=api_key)
-            style_prompt = self.settings.get("style_prompt", "") if self.style_var.get() else ""
-            lang = self.lang_map.get(self.lang_choice.get(), "auto")
-            mode = self.mode_map.get(self.mode_choice.get(), "detailed")
-            docstore_path = self.settings.get("docstore_path")
-            top_k = int(self.settings.get("retrieval_top_k", 3))
-            ok, ctx, needs_clar, reason, _ = validate_question(
+            ans, used_ctx = self.controller.send_chat(
                 text,
-                settings=self.settings,
-                client=client,
-                docstore_path=docstore_path,
-                top_k=top_k,
-                embed_model=openai_conf.get("embed_model", "text-embedding-3-small"),
-                topic=self.chat_state.topic_text,
-                history=self.chat_state.history,
-            )
-            if not ok:
-                if needs_clar:
-                    ans = "Potresti fornire maggiori dettagli o chiarire la tua domanda?"
-                else:
-                    m = _REASON_RE.search(reason)
-                    if m:
-                        score = float(m.group("score"))
-                        thr = float(m.group("thr"))
-                        ans = f"Richiesta fuori dominio (score {score:.2f} < {thr:.2f})."
-                    else:
-                        ans = "Richiesta fuori dominio."
-                self.conv.push_assistant(ans)
-                self._append_chat("assistant", ans)
-                self._append_citations([])
-                self.last_activity = time.time()
-                self.status_var.set("🟢 Attivo")
-                return
-            if self.sandbox_var.get():
-                ctx = []
-            else:
-                dom = self.settings.get("domain", {}) or {}
-                prof = dom.get("profile", "")
-                if isinstance(prof, dict):
-                    prof = prof.get("current", "")
-                ctx = retrieve(
-                    text,
-                    self.settings.get("docstore_path", ""),
-                    top_k=int(self.settings.get("retrieval_top_k", 3)),
-                    topic=prof,
-                )
-            pin_ctx = [{"id": f"pin{i}", "text": t} for i, t in enumerate(self.chat_state.pinned)]
-            ctx = pin_ctx + ctx
-            ans, used_ctx = oracle_answer(
-                text,
-                lang,
-                client,
-                self.settings.get("llm_model", "gpt-4o"),
-                style_prompt,
-                context=ctx,
-                history=self.chat_state.history,
-                topic=self.chat_state.topic_text,
-                mode=mode,
+                self.lang_map.get(self.lang_choice.get(), "auto"),
+                self.mode_map.get(self.mode_choice.get(), "detailed"),
+                self.style_var.get(),
+                self.sandbox_var.get(),
             )
             self.last_sources = used_ctx
         except Exception as e:
             ans = f"Errore: {e}"
-        self.conv.push_assistant(ans)
+            self.last_sources = []
         self._append_chat("assistant", ans)
         self._append_citations(self.last_sources)
         self.last_activity = time.time()
@@ -2005,13 +1842,10 @@ class OracoloUI(tk.Tk):
                 f"Domain: topic={dom['topic']} kw={dom['keywords']} weights={dom['weights']} acc={dom['accept_threshold']} clar={dom['clarify_margin']} wake={dom['always_accept_wake']}\n",
                 "DOMAIN",
             )
-            routed_save(
-                self.base_settings,
-                self.local_settings,
-                self.settings,
-                self.root_dir,
-                self._append_log,
-            )
+            self.controller.save_settings(self._append_log)
+            self.base_settings = self.controller.base_settings
+            self.local_settings = self.controller.local_settings
+            self.settings = self.controller.settings
             win.destroy()
 
         ttk.Button(win, text="OK", command=on_ok).grid(row=8, column=0, columnspan=2, pady=10)
@@ -2117,14 +1951,10 @@ class OracoloUI(tk.Tk):
         self.settings["topic_threshold"] = float(self.topic_threshold.get())
         self.settings["keywords"] = self.keywords
         try:
-            routed_save(
-                self.base_settings,
-                self.local_settings,
-                self.settings,
-                self.root_dir,
-                self._append_log,
-            )
-            self.base_settings, self.local_settings, self.settings = load_settings_pair(self.root_dir)
+            self.controller.save_settings(self._append_log)
+            self.base_settings = self.controller.base_settings
+            self.local_settings = self.controller.local_settings
+            self.settings = self.controller.settings
             self.keywords = list(self.settings.get("keywords", []))
             self.keyword_listbox.delete(0, "end")
             for kw in self.keywords:

--- a/OcchioOnniveggente/src/ui_controller.py
+++ b/OcchioOnniveggente/src/ui_controller.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import copy
+import re
+from pathlib import Path
+from typing import Any, Callable
+
+import yaml
+from openai import OpenAI
+
+from src.chat import ChatState
+from src.conversation import ConversationManager
+from src.config import get_openai_api_key
+from src.domain import validate_question
+from src.oracle import oracle_answer
+from src.retrieval import retrieve
+
+
+_REASON_RE = re.compile(
+    r"kw=(?P<kw>[-0-9.]+) emb=(?P<emb>[-0-9.]+) rag=(?P<rag>[-0-9.]+) score=(?P<score>[-0-9.]+) thr=(?P<thr>[-0-9.]+)"
+)
+
+
+def deep_update(base: dict, upd: dict) -> dict:
+    for k, v in (upd or {}).items():
+        if isinstance(v, dict) and isinstance(base.get(k), dict):
+            deep_update(base[k], v)
+        else:
+            base[k] = v
+    return base
+
+
+def deep_copy(d: dict) -> dict:
+    return copy.deepcopy(d or {})
+
+
+def load_settings_pair(root: Path) -> tuple[dict, dict, dict]:
+    """Return base, local and merged settings dictionaries."""
+    base_p = root / "settings.yaml"
+    local_p = root / "settings.local.yaml"
+
+    base = {}
+    local = {}
+    if base_p.exists():
+        base = yaml.safe_load(base_p.read_text(encoding="utf-8")) or {}
+    if local_p.exists():
+        local = yaml.safe_load(local_p.read_text(encoding="utf-8")) or {}
+
+    merged = deep_copy(base)
+    merged = deep_update(merged, deep_copy(local))
+    return base, local, merged
+
+
+def routed_save(
+    base_now: dict,
+    local_now: dict,
+    merged_new: dict,
+    root: Path,
+    log_fn: Callable[[str, str], None] | None = None,
+) -> None:
+    """Split settings saving between base and local files."""
+    local_out = deep_copy(local_now)
+    local_out.setdefault("audio", {})
+    local_out["debug"] = bool(merged_new.get("debug", local_out.get("debug", False)))
+
+    audio_new = deep_copy(merged_new.get("audio", {}))
+    if "input_device" in audio_new:
+        local_out["audio"]["input_device"] = audio_new.get(
+            "input_device", local_out["audio"].get("input_device")
+        )
+    if "output_device" in audio_new:
+        local_out["audio"]["output_device"] = audio_new.get(
+            "output_device", local_out["audio"].get("output_device")
+        )
+
+    base_out = deep_copy(merged_new)
+    base_out.pop("debug", None)
+    if "audio" in base_out:
+        base_out["audio"].pop("input_device", None)
+        base_out["audio"].pop("output_device", None)
+
+    base_changed = base_out != base_now
+    local_changed = local_out != local_now
+
+    (root / "settings.yaml").write_text(
+        yaml.safe_dump(base_out, sort_keys=False, allow_unicode=True), encoding="utf-8"
+    )
+    if base_changed and log_fn is not None:
+        log_fn("Aggiornato settings.yaml\n", "MISC")
+    (root / "settings.local.yaml").write_text(
+        yaml.safe_dump(local_out, sort_keys=False, allow_unicode=True), encoding="utf-8"
+    )
+    if local_changed and log_fn is not None:
+        log_fn("Aggiornato settings.local.yaml\n", "MISC")
+
+
+class UiController:
+    """Business logic for the Tkinter UI."""
+
+    def __init__(self, root_dir: Path) -> None:
+        self.root_dir = root_dir
+        self.reload_settings()
+
+    def reload_settings(self) -> None:
+        self.base_settings, self.local_settings, self.settings = load_settings_pair(self.root_dir)
+        chat_conf = self.settings.get("chat", {})
+        self.conv = ConversationManager()
+        self.chat_state: ChatState = self.conv.chat
+        if chat_conf.get("enabled", True):
+            self.chat_state.max_turns = int(chat_conf.get("max_turns", 10))
+        else:
+            self.chat_state.max_turns = 0
+        pj = chat_conf.get("persist_jsonl")
+        if pj:
+            self.chat_state.persist_jsonl = Path(pj)
+
+    def save_settings(self, log_fn: Callable[[str, str], None] | None = None) -> None:
+        routed_save(
+            self.base_settings,
+            self.local_settings,
+            self.settings,
+            self.root_dir,
+            log_fn,
+        )
+        # refresh references
+        self.base_settings, self.local_settings, self.settings = load_settings_pair(self.root_dir)
+
+    def send_chat(
+        self,
+        text: str,
+        lang: str,
+        mode: str,
+        style_enabled: bool,
+        sandbox: bool,
+    ) -> tuple[str, list[dict[str, str]]]:
+        self.conv.push_user(text)
+        openai_conf = self.settings.get("openai", {})
+        api_key = get_openai_api_key(self.settings)
+        client = OpenAI(api_key=api_key) if api_key else OpenAI()
+        style_prompt = self.settings.get("style_prompt", "") if style_enabled else ""
+        docstore_path = self.settings.get("docstore_path")
+        top_k = int(self.settings.get("retrieval_top_k", 3))
+        ok, ctx, needs_clar, reason, _ = validate_question(
+            text,
+            settings=self.settings,
+            client=client,
+            docstore_path=docstore_path,
+            top_k=top_k,
+            embed_model=openai_conf.get("embed_model", "text-embedding-3-small"),
+            topic=self.chat_state.topic_text,
+            history=self.chat_state.history,
+        )
+        if not ok:
+            if needs_clar:
+                ans = "Potresti fornire maggiori dettagli o chiarire la tua domanda?"
+            else:
+                m = _REASON_RE.search(reason)
+                if m:
+                    score = float(m.group("score"))
+                    thr = float(m.group("thr"))
+                    ans = f"Richiesta fuori dominio (score {score:.2f} < {thr:.2f})."
+                else:
+                    ans = "Richiesta fuori dominio."
+            self.conv.push_assistant(ans)
+            return ans, []
+        if sandbox:
+            ctx = []
+        else:
+            dom = self.settings.get("domain", {}) or {}
+            prof = dom.get("profile", "")
+            if isinstance(prof, dict):
+                prof = prof.get("current", "")
+            ctx = retrieve(
+                text,
+                self.settings.get("docstore_path", ""),
+                top_k=top_k,
+                topic=prof,
+            )
+        pin_ctx = [{"id": f"pin{i}", "text": t} for i, t in enumerate(self.chat_state.pinned)]
+        ctx = pin_ctx + ctx
+        ans, used_ctx = oracle_answer(
+            text,
+            lang,
+            client,
+            self.settings.get("llm_model", "gpt-4o"),
+            style_prompt,
+            context=ctx,
+            history=self.chat_state.history,
+            topic=self.chat_state.topic_text,
+            mode=mode,
+        )
+        self.conv.push_assistant(ans)
+        return ans, used_ctx


### PR DESCRIPTION
## Summary
- add `UiController` module to handle settings and chat operations
- simplify `ui.py` to focus on rendering and events
- delegate chat handling and settings persistence to the controller

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab777d1ed08327b102d4706eecfd66