### PR TITLE
Introduce UIState for shared UI state

### DIFF
--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -33,6 +33,8 @@ from src.conversation import ConversationManager
 from src.oracle import oracle_answer, synthesize
 from src.domain import validate_question
 from src.config import get_openai_api_key
+from src.ui_state import UIState
+from src.ui_controller import UIController
 
 import asyncio
 import numpy as np
@@ -399,8 +401,14 @@ class RealtimeWSClient:
 class OracoloUI(tk.Tk):
     """Interfaccia grafica per l'Oracolo."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        state: UIState | None = None,
+        controller: UIController | None = None,
+    ) -> None:
         super().__init__()
+        self.state = state or UIState()
+        self.controller = controller
         self.root_dir = Path(__file__).resolve().parents[1]
         self.title("Occhio Onniveggente")
 
@@ -529,6 +537,32 @@ class OracoloUI(tk.Tk):
         self.protocol("WM_DELETE_WINDOW", self._on_close)
 
         logging.getLogger().addHandler(UILogHandler(self))
+
+    # ------------------------------ state props ---------------------------- #
+
+    @property
+    def settings(self) -> dict[str, Any]:
+        return self.state.settings
+
+    @settings.setter
+    def settings(self, value: dict[str, Any]) -> None:
+        self.state.settings = value
+
+    @property
+    def conv(self) -> ConversationManager | None:
+        return self.state.conversation
+
+    @conv.setter
+    def conv(self, value: ConversationManager) -> None:
+        self.state.conversation = value
+
+    @property
+    def audio(self) -> Any | None:
+        return self.state.audio
+
+    @audio.setter
+    def audio(self, value: Any | None) -> None:
+        self.state.audio = value
 
     # --------------------------- Menubar & dialogs ------------------------ #
     def _build_menubar(self) -> None:
@@ -2463,7 +2497,9 @@ UILogHandler = OracoloUI.UILogHandler
 
 # ----------------------------- entry point -------------------------------- #
 def main() -> None:
-    app = OracoloUI()
+    state = UIState()
+    controller = UIController(state)
+    app = OracoloUI(state=state, controller=controller)
     app.mainloop()
 
 

--- a/OcchioOnniveggente/src/ui_controller.py
+++ b/OcchioOnniveggente/src/ui_controller.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Any
+
+from src.conversation import ConversationManager
+from src.ui_state import UIState
+
+
+class UIController:
+    """Simple controller that mediates access to :class:`UIState`.
+
+    Components interacting with the UI can use this controller instead of
+    manipulating global variables directly.  Only a subset of behaviour is
+    required for the tests, so the class intentionally keeps a very small
+    surface area.
+    """
+
+    def __init__(self, state: UIState | None = None) -> None:
+        self.state = state or UIState()
+
+    # ------------------------------------------------------------------
+    # configuration
+    @property
+    def settings(self) -> dict[str, Any]:
+        return self.state.settings
+
+    def update_settings(self, new_settings: dict[str, Any]) -> None:
+        self.state.settings = new_settings
+
+    # ------------------------------------------------------------------
+    # conversation
+    @property
+    def conversation(self) -> ConversationManager | None:
+        return self.state.conversation
+
+    def set_conversation(self, conv: ConversationManager) -> None:
+        self.state.conversation = conv
+
+    # ------------------------------------------------------------------
+    # audio reference
+    @property
+    def audio(self) -> Any | None:
+        return self.state.audio
+
+    def set_audio(self, audio: Any | None) -> None:
+        self.state.audio = audio

--- a/OcchioOnniveggente/src/ui_state.py
+++ b/OcchioOnniveggente/src/ui_state.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from src.conversation import ConversationManager
+
+
+@dataclass
+class UIState:
+    """Container for shared UI state.
+
+    The UI previously relied on a couple of module level variables to keep
+    track of the current configuration, the conversation history and any
+    audio handle in use.  Keeping this information in a dedicated object
+    makes it easier to pass the state around explicitly and avoids reliance
+    on globals.
+    """
+
+    settings: dict[str, Any] = field(default_factory=dict)
+    conversation: ConversationManager | None = None
+    audio: Any | None = None


### PR DESCRIPTION
## Summary
- add `UIState` dataclass to encapsulate settings, conversation and audio references
- implement `UIController` to mediate access to `UIState`
- wire `OracoloUI` to use the shared state and pass it from `main`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab7780866083279447d799bc098154