### PR TITLE
Add device configuration validation and error handling

### DIFF
--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -32,6 +32,7 @@ from src.chat import ChatState
 from src.conversation import ConversationManager
 from src.oracle import oracle_answer, synthesize
 from src.domain import validate_question
+from src.validators import validate_device_config
 from src.config import get_openai_api_key
 
 import asyncio
@@ -2143,6 +2144,13 @@ class OracoloUI(tk.Tk):
         if self.proc and self.proc.poll() is None:
             messagebox.showinfo("Oracolo", "È già in esecuzione.")
             return
+        audio_cfg = self.settings.get("audio", {})
+        try:
+            validate_device_config(audio_cfg)
+        except ValueError as e:
+            messagebox.showerror("Audio", str(e))
+            logging.error("Invalid device configuration: %s", e)
+            return
         try:
             self._clear_log()
             env = os.environ.copy()
@@ -2351,6 +2359,12 @@ class OracoloUI(tk.Tk):
 
         # applica dispositivi audio da settings come default
         audio = self.settings.get("audio", {})
+        try:
+            validate_device_config(audio)
+        except ValueError as e:
+            messagebox.showerror("Audio", str(e))
+            logging.error("Invalid device configuration: %s", e)
+            return
         in_dev = audio.get("input_device", None)
         out_dev = audio.get("output_device", None)
         sd.default.device = (in_dev, out_dev)

--- a/OcchioOnniveggente/src/validators.py
+++ b/OcchioOnniveggente/src/validators.py
@@ -1,0 +1,35 @@
+import logging
+from typing import Any, Dict
+
+import sounddevice as sd
+
+logger = logging.getLogger(__name__)
+
+def validate_device_config(cfg: Dict[str, Any]) -> None:
+    """Validate audio device configuration.
+
+    Raises:
+        ValueError: if configuration is invalid.
+    """
+    try:
+        devices = sd.query_devices()
+    except Exception as exc:
+        logger.error("Unable to query audio devices: %s", exc)
+        raise ValueError(f"Impossibile leggere i device audio: {exc}") from exc
+
+    errors: list[str] = []
+    for key, kind in (("input_device", "input"), ("output_device", "output")):
+        dev = cfg.get(key)
+        if dev is None:
+            errors.append(f"{kind} device non configurato")
+            continue
+        if isinstance(dev, int):
+            if dev < 0 or dev >= len(devices):
+                errors.append(f"indice {kind} {dev} non valido")
+        else:
+            if not any(dev == d.get("name") for d in devices):
+                errors.append(f"{kind} device '{dev}' non trovato")
+    if errors:
+        msg = "; ".join(errors)
+        logger.error("Device config validation failed: %s", msg)
+        raise ValueError(msg)

--- a/tests/test_validators_module.py
+++ b/tests/test_validators_module.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "OcchioOnniveggente"))
+
+try:
+    from src import validators
+except OSError:
+    pytest.skip("PortAudio library not available", allow_module_level=True)
+
+
+def test_validate_device_config_invalid_index(monkeypatch):
+    monkeypatch.setattr(validators.sd, "query_devices", lambda: [{"name": "mic"}])
+    with pytest.raises(ValueError):
+        validators.validate_device_config({"input_device": 5, "output_device": 0})
+
+
+def test_validate_device_config_valid(monkeypatch):
+    devices = [{"name": "mic"}, {"name": "spk"}]
+    monkeypatch.setattr(validators.sd, "query_devices", lambda: devices)
+    validators.validate_device_config({"input_device": "mic", "output_device": "spk"})


### PR DESCRIPTION
## Summary
- add `validate_device_config` helper to centralize audio device checks
- call validator in GUI startup paths with message boxes and logging
- cover validator logic with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab7782aeac8327b9d1c46bb58169e8