### PR TITLE
Fix unclosed parenthesis in UI async call

### DIFF
--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -950,7 +950,7 @@ class OracoloUI(tk.Tk):
                 history=self.chat_state.history,
                 topic=self.chat_state.topic_text,
                 mode=mode,
-
+            )
         try:
             ans, used_ctx = self.controller.send_chat(
                 text,


### PR DESCRIPTION
## Summary
- close unclosed parenthesis in `ui.py` for `oracle_answer_async` call

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab7fdc6e28832796b68b69e1ea19cb