### PR TITLE
Remove unused import in oracle module

### DIFF
--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-import io
 import json
 import re
 import uuid


### PR DESCRIPTION
## Summary
- remove unused `io` import from `oracle.py`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab809055c48327804a41d2f4ca1680