### PR TITLE
Fix syntax errors in UI controller

### DIFF
--- a/OcchioOnniveggente/src/ui_controller.py
+++ b/OcchioOnniveggente/src/ui_controller.py
@@ -45,7 +45,7 @@ class UIController:
 
     def set_audio(self, audio: Any | None) -> None:
         self.state.audio = audio
-=======
+
 import copy
 import re
 from pathlib import Path
@@ -237,4 +237,4 @@ class UiController:
         )
         self.conv.push_assistant(ans)
         return ans, used_ctx
- main
+


### PR DESCRIPTION
## Summary
- remove leftover merge marker in `ui_controller.py`
- drop stray text at end of file to restore valid syntax

## Testing
- `python -m py_compile OcchioOnniveggente/src/ui_controller.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab82b6ab8c83279e7408629a93a3f3