### PR TITLE
Fix Tkinter tag configuration padding error

### DIFF
--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -684,23 +684,28 @@ class OracoloUI(tk.Tk):
         self.chat_view.pack(fill="both", expand=True, padx=4, pady=(4, 0))
 
         # Configurazione dei tag per simulare le bolle della chat
+        # Text.tag_config non supporta le opzioni ``padx`` e ``pady``;
+        # in sostituzione utilizziamo i margini e gli spazi verticali.
+        bubble_kwargs = dict(
+            borderwidth=2,
+            relief="solid",
+            lmargin1=6,
+            lmargin2=6,
+            rmargin=6,
+            spacing1=4,
+            spacing3=4,
+        )
         self.chat_view.tag_config(
             "user_msg",
             background="#2d3e4e",
             foreground="#d7fff9",
-            borderwidth=2,
-            relief="solid",
-            padx=6,
-            pady=4,
+            **bubble_kwargs,
         )
         self.chat_view.tag_config(
             "assistant_msg",
             background="#394b59",
             foreground="#ffffff",
-            borderwidth=2,
-            relief="solid",
-            padx=6,
-            pady=4,
+            **bubble_kwargs,
         )
 
         input_frame = ttk.Frame(chat_frame)


### PR DESCRIPTION
## Summary
- replace unsupported `padx`/`pady` tag options in chat view with margin/spacing arguments
- prevent `_tkinter.TclError: unknown option "-padx"`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab8fe94afc832781e8d6725e578d97