### PR TITLE
Fix Tkinter tag padding and scale button icons

### DIFF
--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -601,12 +601,22 @@ class OracoloUI(tk.Tk):
         bar = ttk.Frame(container)
         bar.pack(fill="x", padx=16, pady=(0, 8))
         img_dir = self.root_dir / "img"
-        if Image and ImageTk:
-            self.start_icon = ImageTk.PhotoImage(Image.open(img_dir / "start.png"))
-            self.stop_icon = ImageTk.PhotoImage(Image.open(img_dir / "stop.png"))
-        else:  # pragma: no cover - fallback senza Pillow
-            self.start_icon = tk.PhotoImage(file=str(img_dir / "start.png"))
-            self.stop_icon = tk.PhotoImage(file=str(img_dir / "stop.png"))
+
+        def load_icon(name: str, size: tuple[int, int]) -> tk.PhotoImage:
+            path = img_dir / name
+            if Image and ImageTk:
+                resample = getattr(getattr(Image, "Resampling", Image), "LANCZOS")
+                img = Image.open(path).resize(size, resample)
+                return ImageTk.PhotoImage(img)
+            icon = tk.PhotoImage(file=str(path))
+            w, h = icon.width(), icon.height()
+            # riduzione best-effort se l'immagine è più grande del target
+            if w > size[0] and h > size[1]:
+                icon = icon.subsample(max(1, w // size[0]), max(1, h // size[1]))
+            return icon
+
+        self.start_icon = load_icon("start.png", (32, 32))
+        self.stop_icon = load_icon("stop.png", (32, 32))
 
         self.start_btn = ttk.Button(bar, image=self.start_icon, command=self.start_oracolo)
         self.stop_btn = ttk.Button(bar, image=self.stop_icon, command=self.stop_oracolo, state="disabled")
@@ -684,29 +694,34 @@ class OracoloUI(tk.Tk):
         self.chat_view.pack(fill="both", expand=True, padx=4, pady=(4, 0))
 
         # Configurazione dei tag per simulare le bolle della chat
+        # Text.tag_config non supporta le opzioni ``padx`` e ``pady``;
+        # in sostituzione utilizziamo i margini e gli spazi verticali.
+        bubble_kwargs = dict(
+            borderwidth=2,
+            relief="solid",
+            lmargin1=6,
+            lmargin2=6,
+            rmargin=6,
+            spacing1=4,
+            spacing3=4,
+        )
         self.chat_view.tag_config(
             "user_msg",
             background="#2d3e4e",
             foreground="#d7fff9",
-            borderwidth=2,
-            relief="solid",
-            padx=6,
-            pady=4,
+            **bubble_kwargs,
         )
         self.chat_view.tag_config(
             "assistant_msg",
             background="#394b59",
             foreground="#ffffff",
-            borderwidth=2,
-            relief="solid",
-            padx=6,
-            pady=4,
+            **bubble_kwargs,
         )
 
         input_frame = ttk.Frame(chat_frame)
         input_frame.pack(fill="x", padx=4, pady=(4, 0))
-        self.mic_on_icon = tk.PhotoImage(file=str(self.root_dir / "img" / "mic_on.png"))
-        self.mic_off_icon = tk.PhotoImage(file=str(self.root_dir / "img" / "mic_off.png"))
+        self.mic_on_icon = load_icon("mic_on.png", (24, 24))
+        self.mic_off_icon = load_icon("mic_off.png", (24, 24))
 
         self.mic_canvas = tk.Canvas(input_frame, width=24, height=24, highlightthickness=0)
         self.mic_canvas.pack(side="left")


### PR DESCRIPTION
## Summary
- replace unsupported `padx`/`pady` tag options in chat view with margin/spacing arguments
- constrain start/stop and microphone button icons to fixed pixel sizes via helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab8fe94afc832781e8d6725e578d97