### PR TITLE
Add docs API endpoint and HTML viewer

### DIFF
--- a/OcchioOnniveggente/docs.html
+++ b/OcchioOnniveggente/docs.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Documenti indicizzati</title>
+  <style>
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border: 1px solid #ccc; padding: 4px 8px; }
+    th { background: #eee; }
+  </style>
+</head>
+<body>
+  <h1>Documenti indicizzati</h1>
+  <table id="docs-table">
+    <thead>
+      <tr>
+        <th>Titolo</th>
+        <th>Dominio</th>
+        <th>Regola</th>
+        <th>Stato</th>
+        <th>Confidenza</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+  <script>
+    async function loadDocs() {
+      const params = new URLSearchParams(window.location.search);
+      const resp = await fetch('/api/docs?' + params.toString());
+      const data = await resp.json();
+      const tbody = document.querySelector('#docs-table tbody');
+      tbody.innerHTML = '';
+      data.forEach(doc => {
+        const tr = document.createElement('tr');
+        ['title','domain','rule','status','confidence'].forEach(key => {
+          const td = document.createElement('td');
+          td.textContent = doc[key] ?? '';
+          tr.appendChild(td);
+        });
+        tbody.appendChild(tr);
+      });
+    }
+    loadDocs();
+  </script>
+</body>
+</html>

--- a/OcchioOnniveggente/src/docs_api.py
+++ b/OcchioOnniveggente/src/docs_api.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+import json
+import sys
+from http.server import SimpleHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from urllib.parse import urlparse, parse_qs
+
+# Ensure project root on path to import scripts.ingest_docs
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import ingest_docs  # type: ignore
+
+DOCSTORE_PATH = ROOT / "DataBase" / "index.json"
+
+
+def _get_documents() -> list[dict]:
+    """Load document metadata from the docstore.
+
+    Returns a list of dictionaries containing metadata for each document.
+    """
+    db = ingest_docs._load_db(str(DOCSTORE_PATH))
+    if hasattr(db, "get_documents"):
+        docs = db.get_documents()
+    elif hasattr(db, "_data"):
+        docs = db._data.get("documents", [])  # type: ignore[attr-defined]
+    else:  # pragma: no cover - unlikely fallback
+        docs = []
+    out: list[dict] = []
+    for d in docs:
+        out.append(
+            {
+                "title": d.get("title") or Path(d.get("id", "")).name,
+                "domain": d.get("topic") or d.get("domain", ""),
+                "rule": d.get("rule", ""),
+                "status": d.get("status", "indexed"),
+                "confidence": d.get("confidence", 1.0),
+            }
+        )
+    return out
+
+
+class DocsHandler(SimpleHTTPRequestHandler):
+    """Serve docs metadata and a simple HTML page."""
+
+    def do_GET(self) -> None:  # noqa: N802 (BaseHTTPRequestHandler API)
+        parsed = urlparse(self.path)
+        if parsed.path == "/api/docs":
+            docs = _get_documents()
+            params = parse_qs(parsed.query)
+            # textual filters
+            for key in ("title", "domain", "rule", "status"):
+                if key in params:
+                    needle = params[key][0].lower()
+                    docs = [d for d in docs if needle in str(d.get(key, "")).lower()]
+            # numeric filter: minimum confidence
+            if "min_confidence" in params:
+                try:
+                    thr = float(params["min_confidence"][0])
+                    docs = [d for d in docs if float(d.get("confidence", 0.0)) >= thr]
+                except ValueError:
+                    pass
+            body = json.dumps(docs, ensure_ascii=False).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
+        # fall back to default behaviour (serving static files)
+        return super().do_GET()
+
+
+def run(host: str = "127.0.0.1", port: int = 8000) -> None:
+    """Run a minimal HTTP server serving docs.html and /api/docs."""
+    handler = lambda *args, **kwargs: DocsHandler(*args, directory=str(ROOT), **kwargs)  # type: ignore[arg-type]
+    HTTPServer((host, port), handler).serve_forever()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    try:
+        run()
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
## Summary
- expose `/api/docs` endpoint returning document metadata with optional filtering
- provide `docs.html` that fetches the endpoint and populates a table

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab91d64ce88327b0599297051768f9