### PR TITLE
Add basic web documentation webapp

### DIFF
--- a/OcchioOnniveggente/src/static/styles.css
+++ b/OcchioOnniveggente/src/static/styles.css
@@ -1,0 +1,21 @@
+body {
+    background-color: #121212;
+    color: #e0e0e0;
+    font-family: Arial, sans-serif;
+}
+
+.container {
+    max-width: 800px;
+    margin: 40px auto;
+    padding: 20px;
+    background-color: #1e1e1e;
+    border-radius: 8px;
+}
+
+h1 {
+    color: #40e0d0;
+}
+
+a {
+    color: #40e0d0;
+}

--- a/OcchioOnniveggente/src/templates/docs.html
+++ b/OcchioOnniveggente/src/templates/docs.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <title>Documentazione</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body>
+    <div class="container">
+        <h1>Documentazione</h1>
+        <p>Benvenuto nella documentazione dell'applicazione.</p>
+    </div>
+</body>
+</html>

--- a/OcchioOnniveggente/src/webapp.py
+++ b/OcchioOnniveggente/src/webapp.py
@@ -1,0 +1,13 @@
+from flask import Flask, render_template
+
+app = Flask(__name__, template_folder='templates', static_folder='static')
+
+
+@app.get('/docs')
+def docs() -> str:
+    """Render the documentation page."""
+    return render_template('docs.html')
+
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- Add Flask-based `webapp.py` exposing a `/docs` route
- Serve a new `docs.html` template with dark theme and turquoise accents
- Include stylesheet with dark palette and highlight color

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab91d7366c8327be8005f64bd9feed