### PR TITLE
Add docs options API and HTML client

### DIFF
--- a/OcchioOnniveggente/docs.html
+++ b/OcchioOnniveggente/docs.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Docs Options</title>
+</head>
+<body>
+<h1>Documentation Options</h1>
+<label>
+  <input type="checkbox" id="use_verified" />
+  Use verified documents
+</label>
+<br />
+<label>
+  <input type="checkbox" id="allow_citations" />
+  Allow citations
+</label>
+<br />
+<label>
+  <input type="checkbox" id="block_pii" />
+  Block PII
+</label>
+<br />
+<label for="min_confidence">Minimum confidence:</label>
+<input type="range" id="min_confidence" min="0" max="1" step="0.01" value="0.0" />
+<span id="min_conf_val">0.00</span>
+<br />
+<button id="save">Save</button>
+
+<script>
+const minConf = document.getElementById('min_confidence');
+const minVal = document.getElementById('min_conf_val');
+minConf.addEventListener('input', () => {
+  minVal.textContent = Number(minConf.value).toFixed(2);
+});
+
+function sendOptions() {
+  const payload = {
+    use_verified: document.getElementById('use_verified').checked,
+    allow_citations: document.getElementById('allow_citations').checked,
+    block_pii: document.getElementById('block_pii').checked,
+    min_confidence: parseFloat(document.getElementById('min_confidence').value)
+  };
+  fetch('/api/docs/options', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  }).catch(err => console.error('Options update failed', err));
+}
+
+document.getElementById('save').addEventListener('click', sendOptions);
+</script>
+</body>
+</html>

--- a/OcchioOnniveggente/requirements.txt
+++ b/OcchioOnniveggente/requirements.txt
@@ -13,3 +13,4 @@ Unidecode>=1.3.8
 pydub>=0.25.1
 pydantic>=2
 markdown2>=2.4.12
+fastapi>=0.110.0

--- a/OcchioOnniveggente/src/docs_api.py
+++ b/OcchioOnniveggente/src/docs_api.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+
+from .ui_state import UIState
+
+STATE = UIState()
+ROOT = Path(__file__).resolve().parents[1]
+SETTINGS_PATH = ROOT / "settings.yaml"
+
+app = FastAPI()
+
+
+class DocsOptions(BaseModel):
+    """Options toggled from the documentation UI."""
+
+    use_verified: bool | None = None
+    allow_citations: bool | None = None
+    block_pii: bool | None = None
+    min_confidence: float | None = Field(None, ge=0.0, le=1.0)
+
+
+def _load_settings() -> dict[str, Any]:
+    if SETTINGS_PATH.exists():
+        try:
+            return yaml.safe_load(SETTINGS_PATH.read_text(encoding="utf-8")) or {}
+        except Exception:
+            return {}
+    return {}
+
+
+def _save_settings(data: dict[str, Any]) -> None:
+    SETTINGS_PATH.write_text(
+        yaml.safe_dump(data, sort_keys=False, allow_unicode=True), encoding="utf-8"
+    )
+
+
+@app.post("/api/docs/options")
+def update_docs_options(opts: DocsOptions) -> dict[str, Any]:
+    """Update documentation-related options in memory and on disk."""
+
+    data = _load_settings()
+    payload = {k: v for k, v in opts.model_dump(exclude_none=True).items()}
+    if payload:
+        STATE.settings.update(payload)
+        data.update(payload)
+        _save_settings(data)
+    return {"status": "ok", "settings": STATE.settings}


### PR DESCRIPTION
## Summary
- add FastAPI endpoint `POST /api/docs/options` to update settings and UI state
- expose minimal docs.html page sending toggle and slider values via fetch
- include FastAPI in project requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab91d7585883279d7b0423e646a548