### PR TITLE
Allow default audio devices

### DIFF
--- a/OcchioOnniveggente/src/validators.py
+++ b/OcchioOnniveggente/src/validators.py
@@ -5,12 +5,26 @@ import sounddevice as sd
 
 logger = logging.getLogger(__name__)
 
+
 def validate_device_config(cfg: Dict[str, Any]) -> None:
     """Validate audio device configuration.
+
+    Non-`None` values are checked against the list of available devices. When
+    both devices are ``None`` the function returns early, allowing
+    ``sounddevice`` to use the system defaults.
 
     Raises:
         ValueError: if configuration is invalid.
     """
+
+    input_dev = cfg.get("input_device")
+    output_dev = cfg.get("output_device")
+    if input_dev is None and output_dev is None:
+        logger.info(
+            "Input e output device non configurati: verranno usati quelli di default"
+        )
+        return
+
     try:
         devices = sd.query_devices()
     except Exception as exc:
@@ -21,7 +35,7 @@ def validate_device_config(cfg: Dict[str, Any]) -> None:
     for key, kind in (("input_device", "input"), ("output_device", "output")):
         dev = cfg.get(key)
         if dev is None:
-            errors.append(f"{kind} device non configurato")
+            logger.info("%s device non configurato: uso del device predefinito", kind)
             continue
         if isinstance(dev, int):
             if dev < 0 or dev >= len(devices):

--- a/tests/test_validators_module.py
+++ b/tests/test_validators_module.py
@@ -20,3 +20,17 @@ def test_validate_device_config_valid(monkeypatch):
     devices = [{"name": "mic"}, {"name": "spk"}]
     monkeypatch.setattr(validators.sd, "query_devices", lambda: devices)
     validators.validate_device_config({"input_device": "mic", "output_device": "spk"})
+
+
+def test_validate_device_config_defaults(monkeypatch):
+    def _fail():
+        raise AssertionError("query_devices should not be called")
+
+    monkeypatch.setattr(validators.sd, "query_devices", _fail)
+    validators.validate_device_config({"input_device": None, "output_device": None})
+
+
+def test_validate_device_config_one_default(monkeypatch):
+    devices = [{"name": "mic"}]
+    monkeypatch.setattr(validators.sd, "query_devices", lambda: devices)
+    validators.validate_device_config({"input_device": "mic", "output_device": None})


### PR DESCRIPTION
## Summary
- let validate_device_config accept missing input/output device settings and use sounddevice defaults
- log when default devices are used
- test handling of unset audio devices

## Testing
- `pytest tests/test_validators_module.py -q` *(skipped: PortAudio library not available)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9416c81c8327a4b81d2bc82edf64