### PR TITLE
feat: add Qt QML sci-fi interface

### DIFF
--- a/OcchioOnniveggente/requirements.txt
+++ b/OcchioOnniveggente/requirements.txt
@@ -14,3 +14,4 @@ pydub>=0.25.1
 pydantic>=2
 markdown2>=2.4.12
 fastapi>=0.110.0
+PySide6>=6.6

--- a/OcchioOnniveggente/src/qml/MainSciFi.qml
+++ b/OcchioOnniveggente/src/qml/MainSciFi.qml
@@ -1,0 +1,65 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Effects 1.15
+
+Rectangle {
+    id: root
+    width: 1024
+    height: 640
+    color: "#0a0d12"
+    border.color: "#3df5ff"
+    border.width: 2
+
+    // neon glow effect
+    layer.enabled: true
+    layer.effect: DropShadow {
+        color: "#3df5ff"
+        radius: 20
+        samples: 25
+        verticalOffset: 0
+        horizontalOffset: 0
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 24
+        spacing: 24
+
+        Text {
+            text: "Occhio Onniveggente"
+            color: "#3df5ff"
+            font.pixelSize: 32
+            font.family: "Consolas"
+        }
+
+        Slider {
+            id: volumeSlider
+            from: 0
+            to: 100
+            value: 50
+            Layout.fillWidth: true
+        }
+
+        Switch {
+            id: glowSwitch
+            text: "Glow"
+            checked: true
+        }
+
+        RowLayout {
+            spacing: 12
+
+            Button {
+                text: "Start"
+                onClicked: backend.start()
+            }
+
+            Button {
+                text: "Reload"
+                onClicked: backend.reload()
+            }
+        }
+    }
+}
+

--- a/OcchioOnniveggente/src/ui_qml.py
+++ b/OcchioOnniveggente/src/ui_qml.py
@@ -1,0 +1,44 @@
+"""Qt/QML based UI for Occhio Onniveggente."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from PySide6 import QtCore, QtQml
+from PySide6.QtWidgets import QApplication
+
+from src.ui_controller import UiController
+
+
+class Backend(QtCore.QObject):
+    """Expose a minimal API to QML."""
+
+    def __init__(self, controller: UiController) -> None:
+        super().__init__()
+        self.controller = controller
+
+    @QtCore.Slot()
+    def start(self) -> None:
+        """Stub start command; hook real logic here."""
+        self.controller.reload_settings()
+
+    @QtCore.Slot()
+    def reload(self) -> None:
+        self.controller.reload_settings()
+
+
+def main() -> int:
+    app = QApplication(sys.argv)
+    controller = UiController(Path(__file__).resolve().parent.parent)
+    backend = Backend(controller)
+    engine = QtQml.QQmlApplicationEngine()
+    engine.rootContext().setContextProperty("backend", backend)
+    qml_path = Path(__file__).resolve().parent / "qml" / "MainSciFi.qml"
+    engine.load(QtCore.QUrl.fromLocalFile(qml_path))
+    if not engine.rootObjects():
+        return -1
+    return app.exec()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add PySide6 requirement for Qt-based UI
- implement Qt/QML sci-fi layout prototype
- provide Python entrypoint binding to existing controller

## Testing
- `pytest tests/test_config.py tests/test_domain.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab9b5769588327841405c5216a1ac0