### PR TITLE
Use Qt5Compat GraphicalEffects for DropShadow

### DIFF
--- a/OcchioOnniveggente/README.md
+++ b/OcchioOnniveggente/README.md
@@ -94,3 +94,7 @@ python -m src.ui
 Dal menu **Impostazioni** è possibile selezionare i dispositivi audio e
 configurare la luce via Art-Net/sACN o WLED.
 
+L'interfaccia QML richiede il modulo **Qt5Compat.GraphicalEffects** per
+rendere l'effetto `DropShadow`: assicurati che sia presente nella tua
+installazione di Qt (è incluso in PySide6).
+

--- a/OcchioOnniveggente/src/qml/MainSciFi.qml
+++ b/OcchioOnniveggente/src/qml/MainSciFi.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import QtQuick.Effects 1.15
+import Qt5Compat.GraphicalEffects 1.0 as Effects
 
 Rectangle {
     id: root
@@ -13,7 +13,7 @@ Rectangle {
 
     // neon glow effect
     layer.enabled: true
-    layer.effect: DropShadow {
+    layer.effect: Effects.DropShadow {
         color: "#3df5ff"
         radius: 20
         samples: 25


### PR DESCRIPTION
## Summary
- Switch MainSciFi.qml to import Qt5Compat.GraphicalEffects and apply DropShadow via this module
- Document Qt5Compat.GraphicalEffects module requirement in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab9f0fc0b88327be5730042e8b9b5e