### PR TITLE
Document required Qt QML modules

### DIFF
--- a/OcchioOnniveggente/README.md
+++ b/OcchioOnniveggente/README.md
@@ -94,3 +94,26 @@ python -m src.ui
 Dal menu **Impostazioni** è possibile selezionare i dispositivi audio e
 configurare la luce via Art-Net/sACN o WLED.
 
+
+### Moduli Qt richiesti
+
+L'interfaccia QML utilizza i moduli `Qt5Compat.GraphicalEffects` o `QtQuick.Effects`.
+
+#### Installazione con pip
+
+I moduli sono inclusi in `PySide6` e si installano con:
+
+```bash
+pip install PySide6
+```
+
+#### Pacchetti di sistema
+
+Su Debian/Ubuntu è possibile installarli con:
+
+```bash
+sudo apt install qml6-module-qt5compat-graphicaleffects qml6-module-qtquick-effects
+```
+
+Per altre distribuzioni consulta la documentazione dei pacchetti Qt.
+

--- a/OcchioOnniveggente/requirements.txt
+++ b/OcchioOnniveggente/requirements.txt
@@ -1,3 +1,4 @@
+# Qt QML modules required: Qt5Compat.GraphicalEffects or QtQuick.Effects
 openai>=1.40.0
 python-dotenv>=1.0.1
 numpy>=1.26.0


### PR DESCRIPTION
## Summary
- note Qt QML modules required for the UI in requirements
- document Qt5Compat.GraphicalEffects and QtQuick.Effects with pip and system package installation hints

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab9f10a2a88327880d5db57804c6f6