### PR TITLE
docs: update Qt module instructions

### DIFF
--- a/OcchioOnniveggente/README.md
+++ b/OcchioOnniveggente/README.md
@@ -96,18 +96,21 @@ configurare la luce via Art-Net/sACN o WLED.
 
 
 
-### Modulo Qt richiesto
+### Moduli Qt richiesti
 
-L'interfaccia QML utilizza `QtQuick.Effects` e l'elemento `MultiEffect` per
-gestire ombre e altri effetti.
+L'interfaccia QML utilizza ora `QtQuick.Effects` e l'elemento `MultiEffect`
+al posto di `Qt5Compat.GraphicalEffects` per gestire ombre e altri effetti.
 
 #### Installazione con pip
 
-Il modulo è incluso in `PySide6` e si installa con:
+I moduli si installano con:
 
 ```bash
-pip install PySide6 PySide6-Addons shiboken6
+pip install PySide6-Essentials PySide6-Addons shiboken6
 ```
+
+Chi utilizza PySide6 6.6 può invece installare il pacchetto monolitico
+`PySide6`.
 
 #### Pacchetti di sistema
 


### PR DESCRIPTION
## Summary
- clarify GUI now uses QtQuick.Effects with MultiEffect instead of Qt5Compat.GraphicalEffects
- document new pip install command using PySide6-Essentials and PySide6-Addons, noting monolithic PySide6 for 6.6

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aba8162fa48327be169b52566f4124