### PR TITLE
Fix document ingestion arg conflict and improve log output

### DIFF
--- a/OcchioOnniveggente/scripts/ingest_docs.py
+++ b/OcchioOnniveggente/scripts/ingest_docs.py
@@ -386,7 +386,6 @@ def main() -> None:
     group.add_argument("--remove", nargs="+", help="File o cartelle da rimuovere dall'indice")
     group.add_argument("--reindex", action="store_true", help="Rigenera l'indice rileggendo i file già noti")
     group.add_argument("--clear", action="store_true", help="Svuota completamente l'indice")
-    group.add_argument("--clear", action="store_true", help="Svuota completamente l’indice")
     args = parser.parse_args()
 
     if args.add:

--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -947,7 +947,8 @@ class OracoloUI(tk.Tk):
         self.base_settings = self.controller.base_settings
         self.local_settings = self.controller.local_settings
         self.settings = self.controller.settings
-        self._append_log(f"Profilo attivo: {name}", "DOMAIN")
+        # ensure profile message is separated from subsequent log entries
+        self._append_log(f"Profilo attivo: {name}\n", "DOMAIN")
         if self.ws_client is not None:
             self.ws_client.profile_name = name
             if self.ws_client.ws is not None:


### PR DESCRIPTION
## Summary
- Remove duplicated `--clear` option from document ingestion script to avoid argparse conflicts
- Append newline after profile change log to keep document actions readable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aba8aa901483278a595558e07ecca4