### PR TITLE
Fix QML syntax and effect initialization in MainSciFi.qml

### DIFF
--- a/OcchioOnniveggente/src/qml/MainSciFi.qml
+++ b/OcchioOnniveggente/src/qml/MainSciFi.qml
@@ -11,7 +11,6 @@ Rectangle {
     border.color: "#3df5ff"
     border.width: 2
 
-
     // Neon glow effect: attempt to use MultiEffect from QtQuick.Effects (Qt 6.5+).
     // If QtQuick.Effects is missing (older Qt versions), fall back to
     // DropShadow from Qt5Compat.GraphicalEffects.
@@ -34,11 +33,12 @@ Rectangle {
         try {
             var component = Qt.createComponent("import QtQuick.Effects; MultiEffect { shadowEnabled: true; shadowColor: '#3df5ff' }");
             if (component.status === Component.Ready) {
-                root.layer.effect = component;
+                root.layer.effect = component.createObject(root);
             }
         } catch (e) {
             // QtQuick.Effects module not present; using DropShadow as fallback
         }
+    }
 
     MultiEffect {
         anchors.fill: parent
@@ -48,7 +48,6 @@ Rectangle {
         shadowBlur: 1.0
         shadowHorizontalOffset: 0
         shadowVerticalOffset: 0
-
     }
 
     ColumnLayout {


### PR DESCRIPTION
## Summary
- fix QML syntax error by closing `Component.onCompleted` block
- construct MultiEffect dynamically and instantiate using `createObject`

## Testing
- `python -m OcchioOnniveggente.src.ui_qml` *(fails: libGL.so.1: cannot open shared object file)*
- `pytest tests/test_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aba9d86ac4832788441b6184bbb5b7