### PR TITLE
Validate retries parameter in retry_with_backoff

### DIFF
--- a/OcchioOnniveggente/src/utils.py
+++ b/OcchioOnniveggente/src/utils.py
@@ -19,9 +19,21 @@ def retry_with_backoff(
 ) -> T:
     """Call ``func`` with retries and exponential backoff.
 
+    Parameters
+    ----------
+    func:
+        Callable to invoke.
+    retries:
+        Number of *attempts* to try ``func``. Must be at least ``1``.
+    base_delay:
+        Initial delay in seconds. The delay grows exponentially as
+        ``base_delay * 2**attempt`` for each retry.
+
     Exceptions are counted in :data:`ERROR_COUNTS` keyed by class name.
-    The delay grows exponentially: ``base_delay * 2**attempt``.
     """
+
+    if retries < 1:
+        raise ValueError("retries must be >= 1")
 
     for attempt in range(retries):
         try:

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,6 +1,8 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from OcchioOnniveggente.src.utils import retry_with_backoff, ERROR_COUNTS
 
@@ -22,3 +24,9 @@ def test_retry_with_backoff_counts_errors():
     res = retry_with_backoff(flaky, retries=5, base_delay=0.01)
     assert res == 123
     assert ERROR_COUNTS["MyError"] == 2
+
+
+def test_retry_with_backoff_requires_positive_retries():
+    """Passing ``retries`` less than 1 should raise ``ValueError``."""
+    with pytest.raises(ValueError):
+        retry_with_backoff(lambda: None, retries=0)


### PR DESCRIPTION
## Summary
- ensure retry_with_backoff requires at least one attempt and document parameter
- cover invalid retries with new test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abacc8b3a48327999828cb01be2026