### PR TITLE
Fix QML root to display window

### DIFF
--- a/OcchioOnniveggente/src/qml/MainSciFi.qml
+++ b/OcchioOnniveggente/src/qml/MainSciFi.qml
@@ -3,60 +3,66 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import QtQuick.Effects
 
-Rectangle {
+Window {
     id: root
+    visible: true
     width: 1024
     height: 640
     color: "#0a0d12"
-    border.color: "#3df5ff"
-    border.width: 2
 
-    layer.enabled: true
-    layer.effect: MultiEffect {
-        shadowEnabled: true
-        shadowColor: "#3df5ff"
-        shadowBlur: 1.0
-        shadowHorizontalOffset: 0
-        shadowVerticalOffset: 0
-    }
-
-    ColumnLayout {
+    Rectangle {
         anchors.fill: parent
-        anchors.margins: 24
-        spacing: 24
+        color: "transparent"
+        border.color: "#3df5ff"
+        border.width: 2
 
-        Text {
-            text: "Occhio Onniveggente"
-            color: "#3df5ff"
-            font.pixelSize: 32
-            font.family: "Consolas"
+        layer.enabled: true
+        layer.effect: MultiEffect {
+            shadowEnabled: true
+            shadowColor: "#3df5ff"
+            shadowBlur: 1.0
+            shadowHorizontalOffset: 0
+            shadowVerticalOffset: 0
         }
 
-        Slider {
-            id: volumeSlider
-            from: 0
-            to: 100
-            value: 50
-            Layout.fillWidth: true
-        }
+        ColumnLayout {
+            anchors.fill: parent
+            anchors.margins: 24
+            spacing: 24
 
-        Switch {
-            id: glowSwitch
-            text: "Glow"
-            checked: true
-        }
-
-        RowLayout {
-            spacing: 12
-
-            Button {
-                text: "Start"
-                onClicked: backend.start()
+            Text {
+                text: "Occhio Onniveggente"
+                color: "#3df5ff"
+                font.pixelSize: 32
+                font.family: "Consolas"
             }
 
-            Button {
-                text: "Reload"
-                onClicked: backend.reload()
+            Slider {
+                id: volumeSlider
+                from: 0
+                to: 100
+                value: 50
+                Layout.fillWidth: true
+            }
+
+            Switch {
+                id: glowSwitch
+                text: "Glow"
+                checked: true
+            }
+
+            RowLayout {
+                spacing: 12
+
+                Button {
+                    text: "Start"
+                    onClicked: backend.start()
+                }
+
+                Button {
+                    text: "Reload"
+                    onClicked: backend.reload()
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- move border and layer effect into a Rectangle within the Window root to avoid invalid property errors

## Testing
- `pytest`
- `QT_QPA_PLATFORM=offscreen python -m src.ui_qml` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68abae06595c8327a1afbd5d86d860d0