### PR TITLE
Add Qt/QML frontend skeleton for Oracolo

### DIFF
--- a/OcchioOnniveggente/src/frontend_qt/CMakeLists.txt
+++ b/OcchioOnniveggente/src/frontend_qt/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.16)
+project(oracolo_client LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Qt6 6.2 COMPONENTS Quick WebSockets Multimedia REQUIRED)
+
+qt_add_executable(oracolo_client
+    main.cpp
+    RealtimeClient.cpp
+)
+
+target_include_directories(oracolo_client PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+qt_add_qml_module(oracolo_client
+    URI Oracolo
+    VERSION 1.0
+    QML_FILES
+        qml/MainWindow.qml
+)
+
+target_link_libraries(oracolo_client
+    PRIVATE Qt6::Quick Qt6::WebSockets Qt6::Multimedia)
+
+install(TARGETS oracolo_client
+    BUNDLE DESTINATION .
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/OcchioOnniveggente/src/frontend_qt/RealtimeClient.cpp
+++ b/OcchioOnniveggente/src/frontend_qt/RealtimeClient.cpp
@@ -1,0 +1,55 @@
+#include "RealtimeClient.h"
+#include <QJsonDocument>
+#include <QAudioFormat>
+
+RealtimeClient::RealtimeClient(QObject *parent) : QObject(parent)
+{
+    connect(&m_socket, &QWebSocket::connected, this, &RealtimeClient::onConnected);
+    connect(&m_socket, &QWebSocket::binaryMessageReceived,
+            this, &RealtimeClient::onBinaryMessageReceived);
+    connect(&m_socket, &QWebSocket::textMessageReceived,
+            this, &RealtimeClient::onTextMessageReceived);
+}
+
+void RealtimeClient::connectToServer(const QUrl &url)
+{
+    m_socket.open(url);
+}
+
+void RealtimeClient::sendHello(int sampleRate, int channels)
+{
+    QJsonObject obj{{"type", "hello"}, {"sr", sampleRate}, {"format", "pcm16"}, {"channels", channels}};
+    m_socket.sendTextMessage(QJsonDocument(obj).toJson(QJsonDocument::Compact));
+}
+
+void RealtimeClient::sendText(const QString &text)
+{
+    QJsonObject obj{{"type", "message"}, {"text", text}};
+    m_socket.sendTextMessage(QJsonDocument(obj).toJson(QJsonDocument::Compact));
+}
+
+void RealtimeClient::onConnected()
+{
+    // placeholder for post-connection logic
+}
+
+void RealtimeClient::onBinaryMessageReceived(const QByteArray &message)
+{
+    if (!m_audioOutput) {
+        QAudioFormat format;
+        format.setSampleRate(24000);
+        format.setChannelCount(1);
+        format.setSampleFormat(QAudioFormat::Int16);
+        m_audioOutput = new QAudioOutput(format, this);
+        m_audioDevice = m_audioOutput->start();
+    }
+    if (m_audioDevice)
+        m_audioDevice->write(message);
+}
+
+void RealtimeClient::onTextMessageReceived(const QString &message)
+{
+    QJsonDocument doc = QJsonDocument::fromJson(message.toUtf8());
+    if (doc.isObject())
+        emit jsonMessageReceived(doc.object());
+}

--- a/OcchioOnniveggente/src/frontend_qt/RealtimeClient.h
+++ b/OcchioOnniveggente/src/frontend_qt/RealtimeClient.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <QObject>
+#include <QWebSocket>
+#include <QAudioOutput>
+#include <QIODevice>
+#include <QJsonObject>
+#include <QUrl>
+
+class RealtimeClient : public QObject
+{
+    Q_OBJECT
+public:
+    explicit RealtimeClient(QObject *parent = nullptr);
+
+    Q_INVOKABLE void connectToServer(const QUrl &url);
+    Q_INVOKABLE void sendHello(int sampleRate, int channels);
+    Q_INVOKABLE void sendText(const QString &text);
+
+signals:
+    void jsonMessageReceived(const QJsonObject &obj);
+
+private slots:
+    void onConnected();
+    void onBinaryMessageReceived(const QByteArray &message);
+    void onTextMessageReceived(const QString &message);
+
+private:
+    QWebSocket m_socket;
+    QAudioOutput *m_audioOutput = nullptr;
+    QIODevice *m_audioDevice = nullptr;
+};

--- a/OcchioOnniveggente/src/frontend_qt/main.cpp
+++ b/OcchioOnniveggente/src/frontend_qt/main.cpp
@@ -1,0 +1,20 @@
+#include <QGuiApplication>
+#include <QQmlApplicationEngine>
+#include <QQmlContext>
+#include "RealtimeClient.h"
+
+int main(int argc, char *argv[])
+{
+    QGuiApplication app(argc, argv);
+    QQmlApplicationEngine engine;
+
+    RealtimeClient client;
+    engine.rootContext()->setContextProperty("realtimeClient", &client);
+
+    const QUrl url(u"qrc:/Oracolo/MainWindow.qml"_qs);
+    QObject::connect(&engine, &QQmlApplicationEngine::objectCreationFailed,
+                     &app, [](){ QCoreApplication::exit(-1); }, Qt::QueuedConnection);
+    engine.load(url);
+
+    return app.exec();
+}

--- a/OcchioOnniveggente/src/frontend_qt/qml/MainWindow.qml
+++ b/OcchioOnniveggente/src/frontend_qt/qml/MainWindow.qml
@@ -1,0 +1,94 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Effects
+
+ApplicationWindow {
+    id: root
+    width: 1024
+    height: 640
+    visible: true
+    color: "#0a0d12"
+    title: "Occhio Onniveggente"
+
+    ComboBox {
+        id: modeBox
+        model: ["Museo", "Galleria", "Conferenze", "Didattica"]
+        anchors.left: parent.left
+        anchors.leftMargin: 16
+        anchors.top: parent.top
+        anchors.topMargin: 16
+        onCurrentTextChanged: {
+            realtimeClient.sendText(JSON.stringify({type: "mode", value: currentText}))
+        }
+    }
+
+    TabView {
+        id: tabs
+        anchors.fill: parent
+        anchors.margins: 24
+
+        Tab {
+            title: "Chat"
+            ColumnLayout {
+                anchors.fill: parent
+                spacing: 12
+
+                TextArea {
+                    id: chatArea
+                    readOnly: true
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    textFormat: TextEdit.PlainText
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    TextField {
+                        id: input
+                        Layout.fillWidth: true
+                        placeholderText: "Scrivi..."
+                        onAccepted: {
+                            chatArea.text += "Tu: " + text + "\n"
+                            realtimeClient.sendText(text)
+                            text = ""
+                        }
+                    }
+                    Button {
+                        text: "Invia"
+                        onClicked: input.accepted()
+                    }
+                }
+            }
+        }
+
+        Tab {
+            title: "Documenti"
+            Label {
+                anchors.centerIn: parent
+                text: "Elenco documenti..."
+            }
+        }
+
+        Tab {
+            title: "Impostazioni"
+            Column {
+                anchors.margins: 12
+                anchors.fill: parent
+                spacing: 8
+                Label { text: "Volume generale" }
+                Slider { from: 0; to: 1; value: 1 }
+                CheckBox { text: "Modalità realtime"; checked: true }
+            }
+        }
+    }
+
+    Connections {
+        target: realtimeClient
+        function onJsonMessageReceived(obj) {
+            if (obj.text) {
+                chatArea.text += "Oracolo: " + obj.text + "\n"
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -117,6 +117,25 @@ La GUI offre inoltre:
 - Menu **Strumenti** per esportare la conversazione (TXT/MD/JSON), salvare le
   risposte in audio (WAV/MP3) e scaricare log o profili da condividere
 
+### Front-end Qt/QML (sperimentale)
+
+Per un'interfaccia moderna è incluso uno scheletro di client Qt/QML in
+`src/frontend_qt`. Utilizza `QWebSocket` per la conversazione realtime e
+riproduce l'audio PCM in streaming con `QAudioOutput`.
+
+Compilazione e avvio:
+
+```bash
+cd OcchioOnniveggente/src/frontend_qt
+mkdir build && cd build
+cmake .. && cmake --build .
+./oracolo_client
+```
+
+Il client espone le tab **Chat**, **Documenti** e **Impostazioni** oltre a un
+menu a tendina per selezionare la modalità (Museo, Galleria, Conferenze,
+Didattica).
+
 ---
 
 ## 4. Modalità Realtime (WebSocket)


### PR DESCRIPTION
## Summary
- Add experimental Qt/QML client with WebSocket audio streaming
- Include RealtimeClient class for WebSocket and PCM playback
- Document Qt frontend build steps in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abb54c5db0832791cd2e7ee1b5fdaa