### PR TITLE
feat: add documents tab UI with backend hooks

### DIFF
--- a/OcchioOnniveggente/src/frontend_qt/CMakeLists.txt
+++ b/OcchioOnniveggente/src/frontend_qt/CMakeLists.txt
@@ -18,6 +18,8 @@ qt_add_qml_module(oracolo_client
     VERSION 1.0
     QML_FILES
         qml/MainWindow.qml
+        qml/DocumentTable.qml
+        qml/RulesPanel.qml
 )
 
 target_link_libraries(oracolo_client

--- a/OcchioOnniveggente/src/frontend_qt/RealtimeClient.cpp
+++ b/OcchioOnniveggente/src/frontend_qt/RealtimeClient.cpp
@@ -28,6 +28,18 @@ void RealtimeClient::sendText(const QString &text)
     m_socket.sendTextMessage(QJsonDocument(obj).toJson(QJsonDocument::Compact));
 }
 
+void RealtimeClient::requestDocuments()
+{
+    QJsonObject obj{{"type", "list_docs"}};
+    m_socket.sendTextMessage(QJsonDocument(obj).toJson(QJsonDocument::Compact));
+}
+
+void RealtimeClient::applyRules(const QJsonObject &rules)
+{
+    QJsonObject obj{{"type", "apply_rules"}, {"rules", rules}};
+    m_socket.sendTextMessage(QJsonDocument(obj).toJson(QJsonDocument::Compact));
+}
+
 void RealtimeClient::onConnected()
 {
     // placeholder for post-connection logic
@@ -50,6 +62,10 @@ void RealtimeClient::onBinaryMessageReceived(const QByteArray &message)
 void RealtimeClient::onTextMessageReceived(const QString &message)
 {
     QJsonDocument doc = QJsonDocument::fromJson(message.toUtf8());
-    if (doc.isObject())
-        emit jsonMessageReceived(doc.object());
+    if (doc.isObject()) {
+        QJsonObject obj = doc.object();
+        if (obj.contains("documents") && obj.value("documents").isArray())
+            emit documentsReceived(obj.value("documents").toArray());
+        emit jsonMessageReceived(obj);
+    }
 }

--- a/OcchioOnniveggente/src/frontend_qt/RealtimeClient.h
+++ b/OcchioOnniveggente/src/frontend_qt/RealtimeClient.h
@@ -5,6 +5,7 @@
 #include <QAudioOutput>
 #include <QIODevice>
 #include <QJsonObject>
+#include <QJsonArray>
 #include <QUrl>
 
 class RealtimeClient : public QObject
@@ -16,9 +17,12 @@ public:
     Q_INVOKABLE void connectToServer(const QUrl &url);
     Q_INVOKABLE void sendHello(int sampleRate, int channels);
     Q_INVOKABLE void sendText(const QString &text);
+    Q_INVOKABLE void requestDocuments();
+    Q_INVOKABLE void applyRules(const QJsonObject &rules);
 
 signals:
     void jsonMessageReceived(const QJsonObject &obj);
+    void documentsReceived(const QJsonArray &docs);
 
 private slots:
     void onConnected();

--- a/OcchioOnniveggente/src/frontend_qt/qml/DocumentTable.qml
+++ b/OcchioOnniveggente/src/frontend_qt/qml/DocumentTable.qml
@@ -1,0 +1,53 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+ListView {
+    id: table
+    property var documents: []
+    property string filterText: ""
+    property var selectedDocument: null
+
+    model: ListModel { id: docModel }
+
+    function refreshModel() {
+        docModel.clear()
+        for (var i = 0; i < documents.length; ++i) {
+            var d = documents[i]
+            if (filterText === "" ||
+                (d.title && d.title.toLowerCase().indexOf(filterText.toLowerCase()) !== -1)) {
+                docModel.append(d)
+            }
+        }
+        if (currentIndex >= docModel.count) {
+            selectedDocument = null
+        }
+    }
+
+    onDocumentsChanged: refreshModel()
+    onFilterTextChanged: refreshModel()
+
+    delegate: Rectangle {
+        width: table.width
+        height: 28
+        color: ListView.isCurrentItem ? "#1e1e1e" : "transparent"
+        RowLayout {
+            anchors.fill: parent
+            spacing: 8
+            Text { text: model.title; Layout.preferredWidth: 200 }
+            Text { text: model.domain; Layout.preferredWidth: 120 }
+            Text { text: model.rule; Layout.preferredWidth: 120 }
+            Text { text: model.status; Layout.preferredWidth: 100 }
+            Text { text: model.confidence; Layout.preferredWidth: 60 }
+        }
+        MouseArea {
+            anchors.fill: parent
+            onClicked: {
+                table.currentIndex = index
+                table.selectedDocument = model
+            }
+        }
+    }
+
+    ScrollBar.vertical: ScrollBar {}
+}

--- a/OcchioOnniveggente/src/frontend_qt/qml/MainWindow.qml
+++ b/OcchioOnniveggente/src/frontend_qt/qml/MainWindow.qml
@@ -64,9 +64,53 @@ ApplicationWindow {
 
         Tab {
             title: "Documenti"
-            Label {
-                anchors.centerIn: parent
-                text: "Elenco documenti..."
+            ColumnLayout {
+                anchors.fill: parent
+                spacing: 8
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    TextField {
+                        id: searchField
+                        Layout.fillWidth: true
+                        placeholderText: "Cerca..."
+                        onTextChanged: docTable.filterText = text
+                    }
+                    Button {
+                        text: "Aggiorna"
+                        onClicked: realtimeClient.requestDocuments()
+                    }
+                }
+
+                RulesPanel {
+                    id: rulesPanel
+                    Layout.fillWidth: true
+                    onApplyRules: realtimeClient.applyRules(rules)
+                }
+
+                DocumentTable {
+                    id: docTable
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    onSelectedDocumentChanged: previewArea.text = selectedDocument ? JSON.stringify(selectedDocument, null, 2) : ""
+                }
+
+                TextArea {
+                    id: previewArea
+                    readOnly: true
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 120
+                    text: "Seleziona un documento"
+                }
+            }
+
+            Component.onCompleted: realtimeClient.requestDocuments()
+
+            Connections {
+                target: realtimeClient
+                function onDocumentsReceived(docs) {
+                    docTable.documents = docs
+                }
             }
         }
 

--- a/OcchioOnniveggente/src/frontend_qt/qml/RulesPanel.qml
+++ b/OcchioOnniveggente/src/frontend_qt/qml/RulesPanel.qml
@@ -1,0 +1,24 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+RowLayout {
+    id: rules
+    spacing: 12
+    signal applyRules(var rules)
+
+    CheckBox { id: verifiedBox; text: "Solo verificati" }
+    CheckBox { id: citationsBox; text: "Citazioni" }
+    CheckBox { id: piiBox; text: "Blocca PII" }
+    Label { text: "Confidenza minima" }
+    Slider { id: confidenceSlider; from: 0; to: 1; stepSize: 0.1; value: 0.5; Layout.preferredWidth: 120 }
+    Button {
+        text: "Applica"
+        onClicked: rules.applyRules({
+            use_verified: verifiedBox.checked,
+            allow_citations: citationsBox.checked,
+            block_pii: piiBox.checked,
+            min_confidence: confidenceSlider.value
+        })
+    }
+}


### PR DESCRIPTION
## Summary
- add DocumentTable and RulesPanel QML components
- flesh out Documents tab with search, filtering, and preview
- extend RealtimeClient with document listing and rule application APIs

## Testing
- `pytest -q`
- `cmake ../src/frontend_qt` *(fails: Could not find a package configuration file provided by "Qt6")*

------
https://chatgpt.com/codex/tasks/task_e_68abbd8f4efc83279f51ff2bacfce271