### PR TITLE
feat: expose QML slots for settings

### DIFF
--- a/OcchioOnniveggente/src/qml/MainSciFi.qml
+++ b/OcchioOnniveggente/src/qml/MainSciFi.qml
@@ -9,6 +9,8 @@ Window {
     width: 1024
     height: 640
     color: "#0a0d12"
+    property var docs: []
+    property var rules: []
 
     Rectangle {
         anchors.fill: parent
@@ -63,6 +65,46 @@ Window {
                     text: "Reload"
                     onClicked: backend.reload()
                 }
+                Button {
+                    text: "Docs"
+                    onClicked: root.docs = backend.get_documents()
+                }
+                Button {
+                    text: "Save"
+                    onClicked: backend.save_config()
+                }
+            }
+
+            RowLayout {
+                spacing: 12
+
+                TextField {
+                    id: ruleField
+                    placeholderText: "kw1, kw2"
+                    Layout.fillWidth: true
+                }
+                Button {
+                    text: "Update"
+                    onClicked: root.rules = backend.update_rules(ruleField.text)
+                }
+            }
+
+            ListView {
+                id: docList
+                model: root.docs
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                delegate: Text {
+                    text: modelData.title ? modelData.title : modelData
+                    color: "#3df5ff"
+                }
+            }
+
+            Text {
+                text: root.rules.join(", ")
+                color: "#3df5ff"
+                wrapMode: Text.Wrap
+                Layout.fillWidth: true
             }
         }
     }

--- a/OcchioOnniveggente/src/ui_qml.py
+++ b/OcchioOnniveggente/src/ui_qml.py
@@ -1,6 +1,7 @@
 """Qt/QML based UI for Occhio Onniveggente."""
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -25,6 +26,54 @@ class Backend(QtCore.QObject):
     @QtCore.Slot()
     def reload(self) -> None:
         self.controller.reload_settings()
+
+    # ------------------------------------------------------------------
+    # Settings & documents helpers exposed to QML
+
+    @QtCore.Slot(result="QVariantList")
+    def get_documents(self) -> list:
+        """Return the documents loaded from the configured docstore."""
+        path = self.controller.settings.get("docstore_path", "DataBase/index.json")
+        try:
+            data = json.loads(Path(path).read_text(encoding="utf-8"))
+        except Exception:
+            return []
+
+        if isinstance(data, dict) and "documents" in data:
+            docs = data["documents"]
+        elif isinstance(data, list):
+            docs = data
+        else:
+            docs = []
+        return docs
+
+    @QtCore.Slot("QVariant", result="QVariant")
+    def update_rules(self, rules) -> list:
+        """Update domain rules/keywords in settings.
+
+        Parameters
+        ----------
+        rules: list | Any
+            Sequence of rule strings coming from QML.  If ``rules`` is a
+            comma separated string it will be split automatically.
+        """
+
+        dom = self.controller.settings.setdefault("domain", {})
+        if isinstance(rules, str):
+            items = [r.strip() for r in rules.split(",") if r.strip()]
+        else:
+            try:
+                items = [str(r).strip() for r in rules if str(r).strip()]
+            except Exception:
+                items = []
+
+        dom["keywords"] = items
+        return dom["keywords"]
+
+    @QtCore.Slot()
+    def save_config(self) -> None:
+        """Persist the current settings to disk."""
+        self.controller.save_settings()
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary
- add backend slots to fetch documents, update rules, and save settings
- wire QML UI to new slots and display returned values

## Testing
- `ruff check OcchioOnniveggente/src/ui_qml.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abbd9089f88327b1e13d0664f1e85f