### PR TITLE
Add Qt/QML frontend skeleton

### DIFF
--- a/oracolo-qml/CMakeLists.txt
+++ b/oracolo-qml/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.20)
+project(OracoloUI LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Qt6 6.5 REQUIRED COMPONENTS
+    Quick Qml QuickControls2 WebSockets Multimedia)
+
+qt_standard_project_setup()
+
+qt_add_executable(OracoloUI
+    src/main.cpp
+    src/RealtimeClient.cpp
+    src/RealtimeClient.h
+)
+
+qt_add_qml_module(OracoloUI
+    URI Oracolo
+    VERSION 1.0
+    QML_FILES
+        src/qml/Main.qml
+        src/qml/pages/ChatPage.qml
+        src/qml/pages/DocumentsPage.qml
+        src/qml/pages/SettingsPage.qml
+        src/qml/components/NeonCard.qml
+        src/qml/components/VUMeter.qml
+        src/qml/components/Waveform.qml
+)
+
+target_link_libraries(OracoloUI PRIVATE
+    Qt6::Quick
+    Qt6::Qml
+    Qt6::QuickControls2
+    Qt6::WebSockets
+    Qt6::Multimedia
+)

--- a/oracolo-qml/src/RealtimeClient.cpp
+++ b/oracolo-qml/src/RealtimeClient.cpp
@@ -1,0 +1,106 @@
+#include "RealtimeClient.h"
+#include <QAudioDevice>
+#include <QMediaDevices>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QtEndian>
+#include <cmath>
+
+RealtimeClient::RealtimeClient(QObject* parent) : QObject(parent) {
+    connect(&m_ws, &QWebSocket::connected, this, &RealtimeClient::onConnected);
+    connect(&m_ws, &QWebSocket::disconnected, this, &RealtimeClient::onDisconnected);
+    connect(&m_ws, &QWebSocket::textMessageReceived, this, &RealtimeClient::onTextMessage);
+    connect(&m_ws, &QWebSocket::binaryMessageReceived, this, &RealtimeClient::onBinaryMessage);
+
+    // Audio format: 24kHz, mono, PCM 16-bit
+    m_format.setSampleRate(24000);
+    m_format.setChannelCount(1);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
+    m_format.setSampleFormat(QAudioFormat::Int16);
+#else
+    m_format.setSampleSize(16);
+    m_format.setCodec("audio/pcm");
+    m_format.setByteOrder(QAudioFormat::LittleEndian);
+    m_format.setSampleType(QAudioFormat::SignedInt);
+#endif
+}
+
+void RealtimeClient::setupAudio() {
+    QAudioDevice dev = QMediaDevices::defaultAudioOutput();
+    m_sink = std::make_unique<QAudioSink>(dev, m_format, this);
+    m_output = m_sink->start(); // push mode: we write() PCM bytes here
+}
+
+void RealtimeClient::connectToUrl(const QUrl& url) {
+    if (m_connected) return;
+    m_ws.open(url);
+}
+
+void RealtimeClient::disconnectFromServer() {
+    if (!m_connected) return;
+    m_ws.close();
+}
+
+void RealtimeClient::onConnected() {
+    m_connected = true;
+    emit connectedChanged();
+
+    if (!m_sink) setupAudio();
+
+    // handshake
+    QJsonObject hello{
+        {"type", "hello"},
+        {"sr", 24000},
+        {"format", "pcm_s16le"},
+        {"channels", 1}
+    };
+    m_ws.sendTextMessage(QString::fromUtf8(QJsonDocument(hello).toJson(QJsonDocument::Compact)));
+}
+
+void RealtimeClient::onDisconnected() {
+    m_connected = false;
+    emit connectedChanged();
+}
+
+void RealtimeClient::onTextMessage(const QString& text) {
+    const auto doc = QJsonDocument::fromJson(text.toUtf8());
+    if (!doc.isObject()) return;
+    const auto obj = doc.object();
+    const auto type = obj.value("type").toString();
+    if (type == "partial") {
+        m_partial = obj.value("text").toString();
+        emit partialChanged();
+    } else if (type == "answer") {
+        m_answer = obj.value("text").toString();
+        emit answerChanged();
+    } // else: ignore
+}
+
+void RealtimeClient::onBinaryMessage(const QByteArray& data) {
+    // stream to audio device
+    if (m_output) {
+        m_output->write(data);
+    }
+    // compute simple RMS for VU
+    const int16_t* s = reinterpret_cast<const int16_t*>(data.constData());
+    const int count = data.size() / 2;
+    if (count > 0) {
+        double sumsq = 0.0;
+        for (int i=0; i<count; ++i) {
+            const double v = s[i] / 32768.0;
+            sumsq += v*v;
+        }
+        double rms = std::sqrt(sumsq / count);
+        double newLevel = std::clamp(rms * 2.0, 0.0, 1.0); // scale a gusto
+        if (std::abs(newLevel - m_level) > 0.01) {
+            m_level = newLevel;
+            emit levelChanged();
+        }
+    }
+}
+
+void RealtimeClient::sendBargeIn() {
+    if (!m_connected) return;
+    QJsonObject obj{{"type", "barge_in"}};
+    m_ws.sendTextMessage(QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact)));
+}

--- a/oracolo-qml/src/RealtimeClient.h
+++ b/oracolo-qml/src/RealtimeClient.h
@@ -1,0 +1,55 @@
+#pragma once
+#include <QObject>
+#include <QWebSocket>
+#include <QAudioFormat>
+#include <QAudioSink>
+#include <QIODevice>
+#include <QTimer>
+#include <memory>
+
+class RealtimeClient : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(bool connected READ connected NOTIFY connectedChanged)
+    Q_PROPERTY(QString partial READ partial NOTIFY partialChanged)
+    Q_PROPERTY(QString answer READ answer NOTIFY answerChanged)
+    Q_PROPERTY(qreal level READ level NOTIFY levelChanged)
+
+public:
+    explicit RealtimeClient(QObject* parent = nullptr);
+
+    Q_INVOKABLE void connectToUrl(const QUrl& url);
+    Q_INVOKABLE void disconnectFromServer();
+    Q_INVOKABLE void sendBargeIn();
+
+    bool connected() const { return m_connected; }
+    QString partial() const { return m_partial; }
+    QString answer() const { return m_answer; }
+    qreal level() const { return m_level; }
+
+signals:
+    void connectedChanged();
+    void partialChanged();
+    void answerChanged();
+    void levelChanged();
+    void error(QString message);
+
+private slots:
+    void onConnected();
+    void onTextMessage(const QString& text);
+    void onBinaryMessage(const QByteArray& data);
+    void onDisconnected();
+
+private:
+    void setupAudio();
+
+    QWebSocket m_ws;
+    bool m_connected = false;
+
+    QString m_partial;
+    QString m_answer;
+    qreal m_level = 0.0; // 0..1
+
+    QAudioFormat m_format;
+    std::unique_ptr<QAudioSink> m_sink;
+    QIODevice* m_output = nullptr; // device returned by sink->start()
+};

--- a/oracolo-qml/src/main.cpp
+++ b/oracolo-qml/src/main.cpp
@@ -1,0 +1,25 @@
+#include <QGuiApplication>
+#include <QQmlApplicationEngine>
+#include <QQmlContext>
+#include <QtQuickControls2>
+#include "RealtimeClient.h"
+
+int main(int argc, char *argv[]) {
+    QGuiApplication app(argc, argv);
+    QQuickStyle::setStyle("Fusion"); // base, poi customizzi in QML
+
+    QQmlApplicationEngine engine;
+
+    // Istanza client realtime (WS + audio)
+    auto *rt = new RealtimeClient(&engine);
+    engine.rootContext()->setContextProperty("rt", rt);
+
+    const QUrl url(u"qrc:/Oracolo/src/qml/Main.qml"_qs);
+    QObject::connect(&engine, &QQmlApplicationEngine::objectCreated, &app,
+                     [url](QObject *obj, const QUrl &objUrl) {
+                         if (!obj && url == objUrl) QCoreApplication::exit(-1);
+                     }, Qt::QueuedConnection);
+    engine.load(url);
+
+    return app.exec();
+}

--- a/oracolo-qml/src/qml/Main.qml
+++ b/oracolo-qml/src/qml/Main.qml
@@ -1,0 +1,114 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Effects
+
+ApplicationWindow {
+  id: win
+  width: 1200
+  height: 800
+  visible: true
+  title: "Occhio Onniveggente · Oracolo ✨"
+
+  // Palette base
+  property color bg: "#0B1020"
+  property color card: "#10182A"
+  property color accent: "#00E5FF"
+  property color text: "#D7FFF9"
+
+  Rectangle { anchors.fill: parent; color: bg }
+
+  // Sidebar (Modalità)
+  Rectangle {
+    id: sidebar
+    width: 240; anchors.top: parent.top; anchors.bottom: parent.bottom; anchors.left: parent.left
+    color: "#0E1422"
+    layer.enabled: true
+    layer.effect: MultiEffect {
+      shadowEnabled: true; shadowColor: "#00131A"; shadowBlur: 0.6
+      brightness: 0.02
+    }
+
+    Column {
+      anchors.fill: parent; anchors.margins: 16; spacing: 12
+      Label { text: "Modalità"; color: text; font.pixelSize: 16; font.bold: true }
+      ButtonGroup { id: modeGroup }
+      Repeater {
+        model: ["Museo", "Galleria", "Conferenze", "Didattica"]
+        delegate: RadioButton {
+          text: modelData; checked: index === 0; width: parent.width
+          palette.buttonText: text
+          onToggled: if (checked) {
+            // TODO: invia al backend (via REST o WS di controllo) il topic/mode
+            console.log("Mode set:", text)
+          }
+        }
+      }
+
+      // connessione WS
+      Rectangle { height: 1; width: parent.width; color: "#1B263B"; opacity: 0.6 }
+      TextField {
+        id: urlEdit; placeholderText: "ws://127.0.0.1:8765"
+        text: "ws://127.0.0.1:8765"; color: text; background: Rectangle{ color:"#0C1424"; radius: 8 }
+      }
+      Row {
+        spacing: 8
+        Button {
+          text: rt.connected ? "Disconnetti" : "Connetti"
+          onClicked: rt.connected ? rt.disconnectFromServer() : rt.connectToUrl(urlEdit.text)
+        }
+        Rectangle {
+          width: 12; height: 12; radius: 6
+          color: rt.connected ? "#29FF92" : "#FF4D4F"
+          border.color: "#002A1A"; border.width: 1
+        }
+      }
+
+      // VU meter esempio
+      Rectangle { height: 1; width: parent.width; color: "#1B263B"; opacity: 0.6 }
+      Label { text: "Livello Audio"; color: text }
+      Rectangle {
+        width: parent.width - 4; height: 16; radius: 8; color: "#0C1424"
+        Rectangle {
+          anchors.verticalCenter: parent.verticalCenter
+          height: parent.height
+          width: parent.width * rt.level
+          radius: 8
+          gradient: Gradient {
+            GradientStop { position: 0.0; color: "#00E5FF" }
+            GradientStop { position: 1.0; color: "#66FFF2" }
+          }
+        }
+      }
+
+      // Waveform semplice (usa rt.level storico)
+      Waveform {
+        id: wf
+        width: parent.width - 4; height: 60
+        colorLine: accent
+        Component.onCompleted: start()
+        onTick: appendLevel(rt.level)
+      }
+    }
+  }
+
+  // Contenuto (tabs)
+  StackLayout {
+    id: stack
+    anchors { left: sidebar.right; right: parent.right; top: parent.top; bottom: parent.bottom; margins: 16 }
+    currentIndex: tabs.currentIndex
+
+    ChatPage { }
+    DocumentsPage { }
+    SettingsPage { }
+  }
+
+  // Tabs top
+  TabBar {
+    id: tabs
+    anchors { left: sidebar.right; right: parent.right; top: parent.top; margins: 16 }
+    TabButton { text: "Chat" }
+    TabButton { text: "Documenti" }
+    TabButton { text: "Impostazioni" }
+  }
+}

--- a/oracolo-qml/src/qml/components/NeonCard.qml
+++ b/oracolo-qml/src/qml/components/NeonCard.qml
@@ -1,0 +1,21 @@
+import QtQuick
+import QtQuick.Effects
+
+Rectangle {
+  id: root
+  property alias contentItem: content
+  color: "#10182A"; radius: 18; border.color: "#1B263B"; border.width: 1
+
+  layer.enabled: true
+  layer.effect: MultiEffect {
+    shadowEnabled: true
+    shadowColor: "#00E5FF"
+    shadowBlur: 0.55
+    shadowHorizontalOffset: 0
+    shadowVerticalOffset: 0
+    brightness: 0.03
+  }
+
+  default property alias data: content.data
+  Item { id: content; anchors.fill: parent; anchors.margins: 16 }
+}

--- a/oracolo-qml/src/qml/components/VUMeter.qml
+++ b/oracolo-qml/src/qml/components/VUMeter.qml
@@ -1,0 +1,20 @@
+import QtQuick
+
+Item {
+  id: root
+  property real level: 0.0 // 0..1
+  width: 200; height: 16
+  Rectangle {
+    anchors.fill: parent; radius: 8; color: "#0C1424"
+    Rectangle {
+      anchors.verticalCenter: parent.verticalCenter
+      height: parent.height
+      width: parent.width * root.level
+      radius: 8
+      gradient: Gradient {
+        GradientStop { position: 0.0; color: "#00E5FF" }
+        GradientStop { position: 1.0; color: "#66FFF2" }
+      }
+    }
+  }
+}

--- a/oracolo-qml/src/qml/components/Waveform.qml
+++ b/oracolo-qml/src/qml/components/Waveform.qml
@@ -1,0 +1,41 @@
+import QtQuick
+
+Canvas {
+  id: canvas
+  property color colorLine: "#00E5FF"
+  property var history: []
+  signal tick()
+  width: 240; height: 60
+
+  function appendLevel(v) {
+    if (history.length > 120) history.shift()
+    history.push(v)
+    requestAnimationFrame(paint)
+  }
+
+  function start() {
+    // timer “soft” per demo (in un caso reale guida l’update da audio chunk)
+    timer.start()
+  }
+
+  Timer {
+    id: timer; interval: 50; repeat: true
+    onTriggered: canvas.tick()
+  }
+
+  onPaint: {
+    var ctx = getContext("2d")
+    ctx.reset()
+    ctx.clearRect(0,0,width,height)
+    ctx.lineWidth = 2
+    ctx.strokeStyle = colorLine
+    ctx.beginPath()
+    var n = history.length
+    for (var i=0; i<n; ++i) {
+      var x = i * (width / Math.max(1, n-1))
+      var y = height - (history[i] * height)
+      if (i === 0) ctx.moveTo(x,y); else ctx.lineTo(x,y)
+    }
+    ctx.stroke()
+  }
+}

--- a/oracolo-qml/src/qml/pages/ChatPage.qml
+++ b/oracolo-qml/src/qml/pages/ChatPage.qml
@@ -1,0 +1,45 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Oracolo
+
+Item {
+  anchors.fill: parent
+
+  ColumnLayout {
+    anchors.fill: parent; spacing: 12
+
+    NeonCard {
+      Layout.fillWidth: true; Layout.preferredHeight: 120
+      Label { text: "Parziali: " + rt.partial; color: "#D7FFF9"; wrapMode: Text.Wrap }
+    }
+
+    NeonCard {
+      Layout.fillWidth: true; Layout.fillHeight: true
+      Column {
+        anchors.fill: parent; anchors.margins: 0; spacing: 6
+        Label { text: "Ultima risposta"; color: "#66FFF2"; font.bold: true }
+        Flickable {
+          anchors.left: parent.left; anchors.right: parent.right; anchors.bottom: parent.bottom; anchors.top: previous.bottom
+          contentWidth: parent.width; contentHeight: ansText.paintedHeight
+          clip: true
+          Text {
+            id: ansText; width: parent.width; color: "#D7FFF9"; wrapMode: Text.Wrap
+            text: rt.answer.length ? rt.answer : "—"
+          }
+        }
+      }
+    }
+
+    RowLayout {
+      Layout.fillWidth: true
+      TextField {
+        id: input; Layout.fillWidth: true; placeholderText: "Scrivi un prompt testuale (facoltativo)…"
+      }
+      Button {
+        text: "Barge-in"
+        onClicked: rt.sendBargeIn()
+      }
+    }
+  }
+}

--- a/oracolo-qml/src/qml/pages/DocumentsPage.qml
+++ b/oracolo-qml/src/qml/pages/DocumentsPage.qml
@@ -1,0 +1,37 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+Item {
+  anchors.fill: parent
+
+  ColumnLayout {
+    anchors.fill: parent; spacing: 12
+
+    NeonCard {
+      Layout.fillWidth: true; Layout.preferredHeight: 100
+      Column {
+        anchors.fill: parent; spacing: 8
+        Label { text: "Gestione Documenti & Regole"; color: "#D7FFF9"; font.bold: true }
+        Row {
+          spacing: 8
+          Button { text: "Aggiungi documenti…"; onClicked: console.log("TODO: apri file dialog e invia ingest al backend") }
+          Button { text: "Rimuovi…" }
+          Button { text: "Aggiorna indice" }
+        }
+      }
+    }
+
+    NeonCard {
+      Layout.fillWidth: true; Layout.fillHeight: true
+      Column {
+        anchors.fill: parent; spacing: 8
+        Label { text: "Regole/Topic correnti (UI only)"; color: "#66FFF2" }
+        TextArea {
+          anchors.left: parent.left; anchors.right: parent.right; anchors.bottom: parent.bottom; anchors.top: previous.bottom
+          placeholderText: "Scrivi keywords o policy di dominio…"
+        }
+      }
+    }
+  }
+}

--- a/oracolo-qml/src/qml/pages/SettingsPage.qml
+++ b/oracolo-qml/src/qml/pages/SettingsPage.qml
@@ -1,0 +1,43 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+Item {
+  anchors.fill: parent
+
+  GridLayout {
+    anchors.fill: parent; columns: 2; columnSpacing: 16; rowSpacing: 12
+
+    NeonCard {
+      Layout.fillWidth: true; Layout.preferredHeight: 160
+      Column {
+        anchors.fill: parent; spacing: 8
+        Label { text: "Audio Output"; color: "#D7FFF9"; font.bold: true }
+        ComboBox { model: ["Default"] /* TODO: lista dispositivi QT */ }
+        Label { text: "Sample rate: 24 kHz mono s16le"; color: "#9BD7FF" }
+      }
+    }
+
+    NeonCard {
+      Layout.fillWidth: true; Layout.preferredHeight: 160
+      Column {
+        anchors.fill: parent; spacing: 8
+        Label { text: "Server Realtime"; color: "#D7FFF9"; font.bold: true }
+        Label { text: "Protocollo: hello/partial/answer + binario PCM"; color: "#9BD7FF" }
+        Label { text: "Barge-in supportato"; color: "#9BD7FF" }
+      }
+    }
+
+    NeonCard {
+      Layout.columnSpan: 2; Layout.fillWidth: true; Layout.preferredHeight: 120
+      Column {
+        anchors.fill: parent; spacing: 6
+        Label { text: "Aspetto"; color: "#D7FFF9"; font.bold: true }
+        Row { spacing: 8
+          Button { text: "Tema scuro (default)"; }
+          Button { text: "Tema blu-neon"; }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `oracolo-qml` project with CMake build for Qt 6.5+
- implement `RealtimeClient` for websocket audio streaming and barge-in support
- provide QML UI: main window with sidebar and tabs, document management page, neon components

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abc030c8108327ba4e8dd9055855d1