### PR TITLE
Enable Qt meta-object processing in frontend build

### DIFF
--- a/OcchioOnniveggente/src/frontend_qt/CMakeLists.txt
+++ b/OcchioOnniveggente/src/frontend_qt/CMakeLists.txt
@@ -4,11 +4,17 @@ project(oracolo_client LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt6 6.2 COMPONENTS Quick WebSockets Multimedia REQUIRED)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+find_package(Qt6 6.2 COMPONENTS Quick Qml WebSockets Multimedia REQUIRED)
+qt_policy(SET QTP0001 NEW)
 
 qt_add_executable(oracolo_client
     main.cpp
     RealtimeClient.cpp
+    RealtimeClient.h
 )
 
 target_include_directories(oracolo_client PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
## Summary
- ensure Qt policy QTP0001 is set after locating Qt
- include RealtimeClient header so AUTOMOC generates meta-types

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac61262ab88327a6e70153109f2892