### PR TITLE
Fix Documenti tab QML structure

### DIFF
--- a/OcchioOnniveggente/src/frontend_qt/RealtimeClient.h
+++ b/OcchioOnniveggente/src/frontend_qt/RealtimeClient.h
@@ -21,20 +21,14 @@ public:
     Q_INVOKABLE void sendHello(int sampleRate, int channels);
     Q_INVOKABLE void sendText(const QString &text);
     Q_INVOKABLE void sendCommand(const QString &type, const QVariantMap &payload = {});
-
-signals:
-    void jsonMessageReceived(const QJsonObject &obj);
-    void docListReceived(const QJsonArray &docs);
-    void ruleUpdated(const QJsonObject &rule);
-    void policyStatusReceived(const QJsonObject &status);
-
     Q_INVOKABLE void requestDocuments();
     Q_INVOKABLE void applyRules(const QJsonObject &rules);
 
 signals:
     void jsonMessageReceived(const QJsonObject &obj);
     void documentsReceived(const QJsonArray &docs);
-
+    void ruleUpdated(const QJsonObject &rule);
+    void policyStatusReceived(const QJsonObject &status);
 
 private slots:
     void onConnected();

--- a/OcchioOnniveggente/src/frontend_qt/qml/MainWindow.qml
+++ b/OcchioOnniveggente/src/frontend_qt/qml/MainWindow.qml
@@ -11,10 +11,6 @@ ApplicationWindow {
     color: "#0a0d12"
     title: "Occhio Onniveggente"
 
-    ListModel {
-        id: docModel
-    }
-
     ComboBox {
         id: modeBox
         model: ["Museo", "Galleria", "Conferenze", "Didattica"]
@@ -72,26 +68,6 @@ ApplicationWindow {
                 anchors.fill: parent
                 spacing: 8
 
-
-                TableView {
-                    id: docTable
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-                    model: docModel
-                    clip: true
-                    delegate: Rectangle {
-                        implicitHeight: 32
-                        width: docTable.width
-                        color: index % 2 ? "#151a1f" : "#1e242b"
-                        Text {
-                            anchors.verticalCenter: parent.verticalCenter
-                            anchors.left: parent.left
-                            anchors.leftMargin: 8
-                            text: name
-                            color: "white"
-                        }
-                    }
-
                 RowLayout {
                     Layout.fillWidth: true
                     TextField {
@@ -134,7 +110,6 @@ ApplicationWindow {
                 target: realtimeClient
                 function onDocumentsReceived(docs) {
                     docTable.documents = docs
-
                 }
             }
         }
@@ -159,20 +134,6 @@ ApplicationWindow {
         function onJsonMessageReceived(obj) {
             if (obj.text) {
                 chatArea.text += "Oracolo: " + obj.text + "\n"
-            }
-        }
-        function onDocListReceived(docs) {
-            docModel.clear()
-            for (var i = 0; i < docs.length; ++i) {
-                var item = docs[i]
-                if (typeof item === "string")
-                    docModel.append({ name: item })
-                else if (item.name)
-                    docModel.append({ name: item.name })
-                else if (item.title)
-                    docModel.append({ name: item.title })
-                else
-                    docModel.append({ name: JSON.stringify(item) })
             }
         }
         function onRuleUpdated(rule) {


### PR DESCRIPTION
## Summary
- remove leftover TableView and docModel from Documenti tab
- use DocumentTable with search and preview to show documents
- drop unused doc list handler to fix QML syntax errors
- clean up RealtimeClient signals and audio setup for Qt6

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac67893ef08327a68e917ed8bbfd8d