### PR TITLE
Fix Qt audio output initialization for RealtimeClient

### DIFF
--- a/OcchioOnniveggente/src/frontend_qt/RealtimeClient.cpp
+++ b/OcchioOnniveggente/src/frontend_qt/RealtimeClient.cpp
@@ -63,8 +63,6 @@ void RealtimeClient::onBinaryMessageReceived(const QByteArray &message)
         format.setChannelCount(1);
         format.setSampleFormat(QAudioFormat::Int16);
         m_audioOutput = new QAudioSink(QMediaDevices::defaultAudioOutput(), format, this);
-        m_audioOutput = new QAudioOutput(QMediaDevices::defaultAudioOutput(), this);
-        m_audioOutput->setFormat(format);
         m_audioDevice = m_audioOutput->start();
     }
     if (m_audioDevice)


### PR DESCRIPTION
## Summary
- remove leftover QAudioOutput usage in RealtimeClient
- start QAudioSink directly with desired format

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac778ef7c883278f194bbca34e3a3e