### PR TITLE
Fix QML resource path for Qt client

### DIFF
--- a/OcchioOnniveggente/src/frontend_qt/main.cpp
+++ b/OcchioOnniveggente/src/frontend_qt/main.cpp
@@ -12,7 +12,12 @@ int main(int argc, char *argv[])
     RealtimeClient client;
     engine.rootContext()->setContextProperty("realtimeClient", &client);
 
-    const QUrl url(u"qrc:/Oracolo/MainWindow.qml"_s);
+    // When using qt_add_qml_module CMake helper, QML files are embedded under
+    // the prefix `qt/qml/<URI>/`.  The previous URL was missing this prefix,
+    // causing the application to fail to locate the QML resource at runtime.
+    // See: https://doc.qt.io/qt-6/qtqml-cppintegration-topic.html
+
+    const QUrl url(u"qrc:/qt/qml/Oracolo/MainWindow.qml"_s);
     QObject::connect(&engine, &QQmlApplicationEngine::objectCreationFailed,
                      &app, [](){ QCoreApplication::exit(-1); }, Qt::QueuedConnection);
     engine.load(url);


### PR DESCRIPTION
## Summary
- correct QML resource URL in Qt frontend to include `qt/qml` prefix
- document reason to avoid missing `MainWindow.qml`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac7a8517708327b958fcb5451288e9