### PR TITLE
Fix QML resource path for frontend Qt app

### DIFF
--- a/OcchioOnniveggente/src/frontend_qt/main.cpp
+++ b/OcchioOnniveggente/src/frontend_qt/main.cpp
@@ -17,7 +17,7 @@ int main(int argc, char *argv[])
     // causing the application to fail to locate the QML resource at runtime.
     // See: https://doc.qt.io/qt-6/qtqml-cppintegration-topic.html
 
-    const QUrl url(u"qrc:/qt/qml/Oracolo/MainWindow.qml"_s);
+    const QUrl url(u"qrc:/qt/qml/Oracolo/qml/MainWindow.qml"_s);
     QObject::connect(&engine, &QQmlApplicationEngine::objectCreationFailed,
                      &app, [](){ QCoreApplication::exit(-1); }, Qt::QueuedConnection);
     engine.load(url);


### PR DESCRIPTION
## Summary
- point the Qt engine to `qrc:/qt/qml/Oracolo/qml/MainWindow.qml`

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/oracolo_client -platform offscreen` *(fails: QQmlApplicationEngine failed to load component)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7d0fe7c88327b046f7fa04be7c27