### PR TITLE
Use module API to load main QML window

### DIFF
--- a/OcchioOnniveggente/src/frontend_qt/main.cpp
+++ b/OcchioOnniveggente/src/frontend_qt/main.cpp
@@ -12,15 +12,10 @@ int main(int argc, char *argv[])
     RealtimeClient client;
     engine.rootContext()->setContextProperty("realtimeClient", &client);
 
-    // When using qt_add_qml_module CMake helper, QML files are embedded under
-    // the prefix `qt/qml/<URI>/`.  The previous URL was missing this prefix,
-    // causing the application to fail to locate the QML resource at runtime.
-    // See: https://doc.qt.io/qt-6/qtqml-cppintegration-topic.html
+    // Load the main QML file from the Oracolo module.
+    engine.loadFromModule(u"Oracolo"_s, u"MainWindow"_s);
 
-    const QUrl url(u"qrc:/qt/qml/Oracolo/qml/MainWindow.qml"_s);
-    QObject::connect(&engine, &QQmlApplicationEngine::objectCreationFailed,
-                     &app, [](){ QCoreApplication::exit(-1); }, Qt::QueuedConnection);
-    engine.load(url);
-
+    if (engine.rootObjects().isEmpty())
+        return -1;
     return app.exec();
 }


### PR DESCRIPTION
## Summary
- Load `MainWindow` from the `Oracolo` QML module via `loadFromModule` for a correct resource path

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "Qt6")*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac80bdaf8883278dd07e86835f4fe8