### PR TITLE
Add chat bubble component and reorganize chat layout

### DIFF
--- a/oracolo-qml/src/qml/components/ChatBubble.qml
+++ b/oracolo-qml/src/qml/components/ChatBubble.qml
@@ -1,0 +1,30 @@
+import QtQuick
+import QtQuick.Controls
+
+Item {
+    id: root
+    property alias text: message.text
+    property bool fromUser: false
+
+    width: ListView.view ? ListView.view.width : 360
+    implicitHeight: bubble.height + 8
+
+    Rectangle {
+        id: bubble
+        radius: 8
+        color: root.fromUser ? "#66FFF2" : "#333333"
+        anchors.left: root.fromUser ? undefined : parent.left
+        anchors.right: root.fromUser ? parent.right : undefined
+        anchors.margins: 8
+        width: Math.min(message.paintedWidth + 24, root.width * 0.8)
+        height: message.paintedHeight + 16
+
+        Text {
+            id: message
+            anchors.fill: parent
+            anchors.margins: 8
+            wrapMode: Text.Wrap
+            color: root.fromUser ? "#000000" : "#D7FFF9"
+        }
+    }
+}

--- a/oracolo-qml/src/qml/pages/ChatPage.qml
+++ b/oracolo-qml/src/qml/pages/ChatPage.qml
@@ -2,44 +2,55 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import Oracolo
+import "../components"
 
 Item {
   anchors.fill: parent
 
+  ListModel { id: conversationModel }
+
+  Connections {
+    target: rt
+    function onAnswerChanged() {
+      if (rt.answer.length) {
+        conversationModel.append({ text: rt.answer, fromUser: false })
+      }
+    }
+  }
+
   ColumnLayout {
     anchors.fill: parent; spacing: 12
+    anchors.bottomMargin: inputRow.height + 12
 
     NeonCard {
       Layout.fillWidth: true; Layout.preferredHeight: 120
       Label { text: "Parziali: " + rt.partial; color: "#D7FFF9"; wrapMode: Text.Wrap }
     }
 
-    NeonCard {
+    ListView {
+      id: chatView
       Layout.fillWidth: true; Layout.fillHeight: true
-      Column {
-        anchors.fill: parent; anchors.margins: 0; spacing: 6
-        Label { text: "Ultima risposta"; color: "#66FFF2"; font.bold: true }
-        Flickable {
-          anchors.left: parent.left; anchors.right: parent.right; anchors.bottom: parent.bottom; anchors.top: previous.bottom
-          contentWidth: parent.width; contentHeight: ansText.paintedHeight
-          clip: true
-          Text {
-            id: ansText; width: parent.width; color: "#D7FFF9"; wrapMode: Text.Wrap
-            text: rt.answer.length ? rt.answer : "—"
-          }
-        }
-      }
+      model: conversationModel
+      delegate: ChatBubble { text: model.text; fromUser: model.fromUser }
+    }
+  }
+
+  Row {
+    id: inputRow
+    anchors.bottom: parent.bottom
+    anchors.right: parent.right
+    anchors.margins: 12
+    spacing: 8
+
+    TextField {
+      id: input
+      width: 240
+      placeholderText: "Scrivi un prompt testuale (facoltativo)…"
     }
 
-    RowLayout {
-      Layout.fillWidth: true
-      TextField {
-        id: input; Layout.fillWidth: true; placeholderText: "Scrivi un prompt testuale (facoltativo)…"
-      }
-      Button {
-        text: "Barge-in"
-        onClicked: rt.sendBargeIn()
-      }
+    RoundButton {
+      text: "\u{1F3A4}"
+      onClicked: rt.sendBargeIn()
     }
   }
 }


### PR DESCRIPTION
## Summary
- add reusable ChatBubble component to style user and system messages
- switch ChatPage to ListView of ChatBubble and move input controls to bottom-right

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac8c95e0b48327b005c99da83b547b