### PR TITLE
feat(qml): add starfield background and shared color palette

### DIFF
--- a/oracolo-qml/src/qml/Main.qml
+++ b/oracolo-qml/src/qml/Main.qml
@@ -2,6 +2,8 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import QtQuick.Effects
+import "./Palette.js" as Palette
+import "components" as Components
 
 ApplicationWindow {
   id: win
@@ -11,12 +13,43 @@ ApplicationWindow {
   title: "Occhio Onniveggente · Oracolo ✨"
 
   // Palette base
-  property color bg: "#0B1020"
-  property color card: "#10182A"
-  property color accent: "#00E5FF"
-  property color text: "#D7FFF9"
+  property color bg: Palette.bg
+  property color card: Palette.card
+  property color accent: Palette.accent
+  property color text: Palette.text
 
-  Rectangle { anchors.fill: parent; color: bg }
+  // Background gradient with subtle star field
+  Rectangle {
+    anchors.fill: parent
+    gradient: Gradient {
+      GradientStop { position: 0.0; color: Qt.darker(Palette.accent, 3) }
+      GradientStop { position: 1.0; color: Palette.bg }
+    }
+  }
+
+  Canvas {
+    anchors.fill: parent
+    opacity: 0.15
+    onPaint: {
+      var ctx = getContext("2d");
+      ctx.clearRect(0, 0, width, height);
+      ctx.fillStyle = Palette.text;
+      for (var i = 0; i < 100; ++i) {
+        var x = Math.random() * width;
+        var y = Math.random() * height;
+        var r = Math.random() * 1.5;
+        ctx.beginPath();
+        ctx.arc(x, y, r, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    }
+    Component.onCompleted: requestPaint()
+  }
+
+  Components.OrbGlow {
+    radius: 180
+    anchors.centerIn: parent
+  }
 
   // Sidebar (Modalità)
   Rectangle {

--- a/oracolo-qml/src/qml/Palette.js
+++ b/oracolo-qml/src/qml/Palette.js
@@ -1,0 +1,7 @@
+.pragma library
+
+var bg = "#0B1020";
+var card = "#10182A";
+var accent = "#00E5FF";
+var accentLight = "#66FFF2";
+var text = "#D7FFF9";

--- a/oracolo-qml/src/qml/components/ChatBubble.qml
+++ b/oracolo-qml/src/qml/components/ChatBubble.qml
@@ -1,0 +1,24 @@
+import QtQuick
+import QtQuick.Controls
+import "../Palette.js" as Palette
+
+Rectangle {
+  id: bubble
+  property alias text: label.text
+  property bool fromUser: false
+  color: fromUser ? Palette.accent : Palette.card
+  radius: 12
+  border.color: Palette.accent
+  border.width: fromUser ? 0 : 1
+  anchors.margins: 4
+  implicitWidth: label.implicitWidth + 24
+  implicitHeight: label.implicitHeight + 16
+
+  Label {
+    id: label
+    anchors.fill: parent
+    anchors.margins: 8
+    wrapMode: Text.Wrap
+    color: fromUser ? Palette.bg : Palette.text
+  }
+}

--- a/oracolo-qml/src/qml/components/DocumentsPanel.qml
+++ b/oracolo-qml/src/qml/components/DocumentsPanel.qml
@@ -1,0 +1,20 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import "../Palette.js" as Palette
+
+Rectangle {
+  id: panel
+  color: Palette.card
+  radius: 18
+  border.color: Palette.accent
+  border.width: 1
+  property alias contentItem: content
+
+  ColumnLayout {
+    id: content
+    anchors.fill: parent
+    anchors.margins: 16
+    spacing: 8
+  }
+}

--- a/oracolo-qml/src/qml/components/NeonCard.qml
+++ b/oracolo-qml/src/qml/components/NeonCard.qml
@@ -1,15 +1,16 @@
 import QtQuick
 import QtQuick.Effects
+import "../Palette.js" as Palette
 
 Rectangle {
   id: root
   property alias contentItem: content
-  color: "#10182A"; radius: 18; border.color: "#1B263B"; border.width: 1
+  color: Palette.card; radius: 18; border.color: Qt.darker(Palette.card, 1.3); border.width: 1
 
   layer.enabled: true
   layer.effect: MultiEffect {
     shadowEnabled: true
-    shadowColor: "#00E5FF"
+    shadowColor: Palette.accent
     shadowBlur: 0.55
     shadowHorizontalOffset: 0
     shadowVerticalOffset: 0

--- a/oracolo-qml/src/qml/components/OrbGlow.qml
+++ b/oracolo-qml/src/qml/components/OrbGlow.qml
@@ -1,0 +1,19 @@
+import QtQuick
+import "../Palette.js" as Palette
+
+Item {
+  id: orb
+  property real radius: 100
+  width: radius * 2
+  height: width
+  opacity: 0.2
+
+  Rectangle {
+    anchors.fill: parent
+    radius: width / 2
+    gradient: Gradient {
+      GradientStop { position: 0.0; color: Palette.accent }
+      GradientStop { position: 1.0; color: "transparent" }
+    }
+  }
+}

--- a/oracolo-qml/src/qml/components/VUMeter.qml
+++ b/oracolo-qml/src/qml/components/VUMeter.qml
@@ -1,19 +1,20 @@
 import QtQuick
+import "../Palette.js" as Palette
 
 Item {
   id: root
   property real level: 0.0 // 0..1
   width: 200; height: 16
   Rectangle {
-    anchors.fill: parent; radius: 8; color: "#0C1424"
+    anchors.fill: parent; radius: 8; color: Qt.darker(Palette.bg, 1.2)
     Rectangle {
       anchors.verticalCenter: parent.verticalCenter
       height: parent.height
       width: parent.width * root.level
       radius: 8
       gradient: Gradient {
-        GradientStop { position: 0.0; color: "#00E5FF" }
-        GradientStop { position: 1.0; color: "#66FFF2" }
+        GradientStop { position: 0.0; color: Palette.accent }
+        GradientStop { position: 1.0; color: Palette.accentLight }
       }
     }
   }

--- a/oracolo-qml/src/qml/components/Waveform.qml
+++ b/oracolo-qml/src/qml/components/Waveform.qml
@@ -1,8 +1,9 @@
 import QtQuick
+import "../Palette.js" as Palette
 
 Canvas {
   id: canvas
-  property color colorLine: "#00E5FF"
+  property color colorLine: Palette.accent
   property var history: []
   signal tick()
   width: 240; height: 60

--- a/oracolo-qml/src/qml/pages/ChatPage.qml
+++ b/oracolo-qml/src/qml/pages/ChatPage.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import Oracolo
+import "../Palette.js" as Palette
 
 Item {
   anchors.fill: parent
@@ -11,20 +12,22 @@ Item {
 
     NeonCard {
       Layout.fillWidth: true; Layout.preferredHeight: 120
-      Label { text: "Parziali: " + rt.partial; color: "#D7FFF9"; wrapMode: Text.Wrap }
+      color: Palette.card
+      Label { text: "Parziali: " + rt.partial; color: Palette.text; wrapMode: Text.Wrap }
     }
 
     NeonCard {
       Layout.fillWidth: true; Layout.fillHeight: true
+      color: Palette.card
       Column {
         anchors.fill: parent; anchors.margins: 0; spacing: 6
-        Label { text: "Ultima risposta"; color: "#66FFF2"; font.bold: true }
+        Label { text: "Ultima risposta"; color: Palette.accentLight; font.bold: true }
         Flickable {
           anchors.left: parent.left; anchors.right: parent.right; anchors.bottom: parent.bottom; anchors.top: previous.bottom
           contentWidth: parent.width; contentHeight: ansText.paintedHeight
           clip: true
           Text {
-            id: ansText; width: parent.width; color: "#D7FFF9"; wrapMode: Text.Wrap
+            id: ansText; width: parent.width; color: Palette.text; wrapMode: Text.Wrap
             text: rt.answer.length ? rt.answer : "—"
           }
         }

--- a/oracolo-qml/src/qml/pages/DocumentsPage.qml
+++ b/oracolo-qml/src/qml/pages/DocumentsPage.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import "../Palette.js" as Palette
 
 Item {
   anchors.fill: parent
@@ -10,9 +11,10 @@ Item {
 
     NeonCard {
       Layout.fillWidth: true; Layout.preferredHeight: 100
+      color: Palette.card
       Column {
         anchors.fill: parent; spacing: 8
-        Label { text: "Gestione Documenti & Regole"; color: "#D7FFF9"; font.bold: true }
+        Label { text: "Gestione Documenti & Regole"; color: Palette.text; font.bold: true }
         Row {
           spacing: 8
           Button { text: "Aggiungi documenti…"; onClicked: console.log("TODO: apri file dialog e invia ingest al backend") }
@@ -24,9 +26,10 @@ Item {
 
     NeonCard {
       Layout.fillWidth: true; Layout.fillHeight: true
+      color: Palette.card
       Column {
         anchors.fill: parent; spacing: 8
-        Label { text: "Regole/Topic correnti (UI only)"; color: "#66FFF2" }
+        Label { text: "Regole/Topic correnti (UI only)"; color: Palette.accentLight }
         TextArea {
           anchors.left: parent.left; anchors.right: parent.right; anchors.bottom: parent.bottom; anchors.top: previous.bottom
           placeholderText: "Scrivi keywords o policy di dominio…"


### PR DESCRIPTION
## Summary
- replace flat background with gradient starfield and glowing orb
- centralize colors in `Palette.js`
- update components and pages to use palette

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac8c9a6f408327a3a54c909169d78a