### PR TITLE
Enable QML language server config generation

### DIFF
--- a/OcchioOnniveggente/src/frontend_qt/CMakeLists.txt
+++ b/OcchioOnniveggente/src/frontend_qt/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
 
+set(QT_QML_GENERATE_QMLLS_INI ON)
 find_package(Qt6 6.2 COMPONENTS Quick Qml WebSockets Multimedia REQUIRED)
 qt_policy(SET QTP0001 NEW)
 qt_policy(SET QTP0004 NEW)


### PR DESCRIPTION
## Summary
- enable QML language server `.ini` generation in Qt frontend CMake

## Testing
- `cmake -B build -S .` *(fails: Unknown CMake command "qt_policy")*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_68ac9872349883278368a94b4f5981dc