### PR TITLE
chore: exclude build directories from VS Code explorer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.exclude": {
+        "**/build/**": true
+    }
+}


### PR DESCRIPTION
## Summary
- ignore build folders in VS Code file explorer

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac9873879c832791ee85276346b1b3