### PR TITLE
feat: optimize backend performance

### DIFF
--- a/OcchioOnniveggente/scripts/ingest_docs.py
+++ b/OcchioOnniveggente/scripts/ingest_docs.py
@@ -243,7 +243,13 @@ def _detect_language(text: str) -> str:
 
 # ----------------------------- DB loader ------------------------------------- #
 def _load_db(path: str) -> object:
-    # prova a caricare un DocumentDB custom
+    if path.endswith(".db") or "://" in path:
+        try:
+            from src.metadata_store import MetadataStore
+            logging.info("Uso MetadataStore (%s)", path)
+            return MetadataStore(path)
+        except Exception as e:
+            logging.warning("MetadataStore non disponibile: %s", e)
     try:
         module = importlib.import_module("documentdb")
         DocumentDB = getattr(module, "DocumentDB")
@@ -252,6 +258,7 @@ def _load_db(path: str) -> object:
     except Exception:
         logging.info("Uso SimpleDocumentDB (fallback) → %s", path)
         return SimpleDocumentDB(path)
+
 
 
 def _backup_index(index_path: str) -> None:

--- a/OcchioOnniveggente/src/local_audio.py
+++ b/OcchioOnniveggente/src/local_audio.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""Local TTS/STT helpers and simple chunked streaming utilities."""
+
+from pathlib import Path
+from typing import Generator
+
+
+def stream_file(path: Path, chunk_size: int = 4096) -> Generator[bytes, None, None]:
+    """Yield audio chunks from ``path`` for streaming playback."""
+
+    with path.open("rb") as fh:
+        while True:
+            chunk = fh.read(chunk_size)
+            if not chunk:
+                break
+            yield chunk
+
+
+def tts_local(text: str, out_path: Path, lang: str = "it") -> None:
+    """Synthesize ``text`` locally if possible.
+
+    The function tries a couple of lightweight libraries (``gTTS`` and
+    ``pyttsx3``) and falls back to an empty file if neither is available.
+    """
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    try:  # gTTS first because it is tiny and widely available
+        from gtts import gTTS  # type: ignore
+
+        gTTS(text=text, lang=lang).save(out_path.as_posix())
+        return
+    except Exception:
+        pass
+
+    try:  # fall back to pyttsx3 (offline, cross-platform)
+        import pyttsx3  # type: ignore
+
+        engine = pyttsx3.init()
+        engine.save_to_file(text, out_path.as_posix())
+        engine.runAndWait()
+        return
+    except Exception:
+        pass
+
+    # Fallback: create an empty placeholder so callers don't explode
+    out_path.write_bytes(b"")
+
+
+def stt_local(audio_path: Path, lang: str = "it") -> str:
+    """Attempt a local transcription of ``audio_path``.
+
+    The function uses `speech_recognition` with the PocketSphinx backend when
+    available.  It is intentionally simple and meant only as a latency saving
+    fallback.
+    """
+
+    try:
+        import speech_recognition as sr  # type: ignore
+
+        r = sr.Recognizer()
+        with sr.AudioFile(str(audio_path)) as source:
+            audio = r.record(source)
+        try:
+            return r.recognize_sphinx(audio, language=lang)
+        except Exception:
+            return ""
+    except Exception:
+        return ""

--- a/OcchioOnniveggente/src/metadata_store.py
+++ b/OcchioOnniveggente/src/metadata_store.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+"""Lightweight metadata and vector stores for document retrieval.
+
+This module provides two small helpers used to speed up backend operations:
+
+* :class:`MetadataStore` – wraps either SQLite with an FTS5 index or
+  PostgreSQL with a `tsvector` index.  Only a couple of methods are implemented
+  to keep the interface extremely small and dependency free.  If PostgreSQL
+  support is requested but the ``psycopg2`` package is not available, a
+  ``RuntimeError`` is raised at runtime.
+* :class:`VectorStore` – optional FAISS-based vector index with a pure Python
+  fallback based on cosine similarity.  It is purposely minimal and intended
+  for small/medium collections.
+
+The classes are intentionally tiny so they can be imported without pulling in
+heavy dependencies when not used.
+"""
+
+from pathlib import Path
+from typing import Iterable, List, Tuple, Dict, Any
+
+import sqlite3
+import numpy as np
+
+try:  # optional PostgreSQL backend
+    import psycopg2  # type: ignore
+except Exception:  # pragma: no cover - optional
+    psycopg2 = None  # type: ignore
+
+try:  # optional FAISS backend
+    import faiss  # type: ignore
+except Exception:  # pragma: no cover - optional
+    faiss = None  # type: ignore
+
+
+class MetadataStore:
+    """Simple metadata store backed by SQLite FTS5 or PostgreSQL.
+
+    Parameters
+    ----------
+    dsn: str
+        Database connection string.  Use ``sqlite:///path`` or a plain path for
+        SQLite; any string starting with ``postgres`` enables the PostgreSQL
+        backend.
+    """
+
+    def __init__(self, dsn: str):
+        self.backend: str
+        if dsn.startswith("postgres://") or dsn.startswith("postgresql://"):
+            if psycopg2 is None:  # pragma: no cover - optional dependency
+                raise RuntimeError("psycopg2 is required for PostgreSQL support")
+            self.backend = "postgres"
+            self.conn = psycopg2.connect(dsn)  # type: ignore[arg-type]
+            cur = self.conn.cursor()
+            cur.execute(
+                "CREATE TABLE IF NOT EXISTS docs (id TEXT PRIMARY KEY, content TEXT)"
+            )
+            cur.execute(
+                "CREATE INDEX IF NOT EXISTS docs_fts ON docs USING gin(to_tsvector('simple',content))"
+            )
+            self.conn.commit()
+        else:
+            self.backend = "sqlite"
+            path = dsn
+            if dsn.startswith("sqlite://"):
+                path = dsn.split("sqlite://", 1)[1]
+            p = Path(path)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            self.conn = sqlite3.connect(p)
+            # id stored as UNINDEXED so only ``content`` participates in FTS
+            self.conn.execute(
+                "CREATE VIRTUAL TABLE IF NOT EXISTS docs USING fts5(id UNINDEXED, content)"
+            )
+
+    # ------------------------------------------------------------------
+    # Basic CRUD operations
+    # ------------------------------------------------------------------
+    def add_documents(self, documents: List[Dict[str, Any]]) -> None:
+        """Insert or replace a batch of documents.
+
+        Each document must at least contain ``id`` and ``text`` keys.
+        Additional metadata is currently ignored but kept to maintain a stable
+        API for future extensions.
+        """
+
+        if not documents:
+            return
+        if self.backend == "postgres":  # pragma: no cover - requires psycopg2
+            cur = self.conn.cursor()
+            for doc in documents:
+                cur.execute(
+                    "INSERT INTO docs(id, content) VALUES (%s, %s) "
+                    "ON CONFLICT(id) DO UPDATE SET content=EXCLUDED.content",
+                    (doc.get("id"), doc.get("text", "")),
+                )
+            self.conn.commit()
+        else:
+            cur = self.conn.cursor()
+            cur.executemany(
+                "INSERT INTO docs(id, content) VALUES (?, ?)",
+                [(d.get("id"), d.get("text", "")) for d in documents],
+            )
+            self.conn.commit()
+
+    def delete_documents(self, ids: List[str]) -> None:
+        if not ids:
+            return
+        if self.backend == "postgres":  # pragma: no cover - requires psycopg2
+            cur = self.conn.cursor()
+            cur.executemany("DELETE FROM docs WHERE id=%s", [(i,) for i in ids])
+            self.conn.commit()
+        else:
+            cur = self.conn.cursor()
+            cur.executemany("DELETE FROM docs WHERE id=?", [(i,) for i in ids])
+            self.conn.commit()
+
+    def get_documents(self) -> List[Dict[str, str]]:
+        cur = self.conn.cursor()
+        cur.execute("SELECT id, content FROM docs")
+        return [{"id": did, "text": txt} for did, txt in cur.fetchall()]
+
+    def clear(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute("DELETE FROM docs")
+        self.conn.commit()
+
+    # ------------------------------------------------------------------
+    # Search utilities
+    # ------------------------------------------------------------------
+    def search(self, query: str, limit: int = 5) -> List[Tuple[str, str]]:
+        """Return ``(id, content)`` tuples matching ``query``."""
+
+        if self.backend == "postgres":  # pragma: no cover - requires psycopg2
+            cur = self.conn.cursor()
+            cur.execute(
+                "SELECT id, content FROM docs WHERE "
+                "to_tsvector('simple',content) @@ plainto_tsquery(%s) LIMIT %s",
+                (query, limit),
+            )
+            return cur.fetchall()
+        else:
+            cur = self.conn.execute(
+                "SELECT id, content FROM docs WHERE docs MATCH ? LIMIT ?",
+                (query, limit),
+            )
+            return cur.fetchall()
+
+
+class VectorStore:
+    """Tiny vector store with optional FAISS backend."""
+
+    def __init__(self, dim: int):
+        self.dim = dim
+        self.ids: List[str] = []
+        self.vectors: List[np.ndarray] = []
+        if faiss is not None:  # pragma: no cover - optional dependency
+            self.index = faiss.IndexFlatL2(dim)
+        else:
+            self.index = None
+
+    def add(self, doc_id: str, vector: Iterable[float]) -> None:
+        vec = np.asarray(list(vector), dtype=np.float32)
+        if vec.size != self.dim:
+            raise ValueError(f"expected vector of size {self.dim}, got {vec.size}")
+        if self.index is not None:  # pragma: no branch - optional
+            self.index.add(vec.reshape(1, -1))
+        self.ids.append(doc_id)
+        self.vectors.append(vec)
+
+    def search(self, vector: Iterable[float], top_k: int = 5) -> List[Tuple[str, float]]:
+        """Return ``(id, score)`` pairs ordered by similarity."""
+
+        q = np.asarray(list(vector), dtype=np.float32)
+        if q.size != self.dim:
+            raise ValueError(f"expected vector of size {self.dim}, got {q.size}")
+
+        if self.index is not None and self.ids:  # pragma: no branch - optional
+            D, I = self.index.search(q.reshape(1, -1), top_k)
+            return [
+                (self.ids[i], float(D[0][j]))
+                for j, i in enumerate(I[0])
+                if 0 <= i < len(self.ids)
+            ]
+
+        # Fallback cosine similarity
+        sims = []
+        for did, vec in zip(self.ids, self.vectors):
+            denom = float(np.linalg.norm(q) * np.linalg.norm(vec))
+            sim = float(np.dot(q, vec) / denom) if denom else 0.0
+            sims.append((did, sim))
+        sims.sort(key=lambda x: x[1], reverse=True)
+        return sims[:top_k]

--- a/OcchioOnniveggente/src/openai_async.py
+++ b/OcchioOnniveggente/src/openai_async.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Utilities to offload expensive OpenAI calls to a thread pool."""
+
+from concurrent.futures import ThreadPoolExecutor, Future
+from typing import Callable, TypeVar, Any
+import asyncio
+
+T = TypeVar("T")
+
+# A small global executor used across the application.  The size is kept
+# conservative so that we do not spawn an excessive amount of threads even if
+# many modules import this helper.
+_EXECUTOR = ThreadPoolExecutor(max_workers=4)
+
+
+def submit(func: Callable[..., T], *args: Any, **kwargs: Any) -> Future:
+    """Submit ``func`` to the shared executor and return a :class:`Future`."""
+
+    return _EXECUTOR.submit(func, *args, **kwargs)
+
+
+def run(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+    """Run ``func`` synchronously in the executor and wait for the result."""
+
+    return submit(func, *args, **kwargs).result()
+
+
+def run_async(func: Callable[..., T], *args: Any, **kwargs: Any) -> asyncio.Future:
+    """Awaitable version of :func:`run` using ``asyncio`` integration."""
+
+    loop = asyncio.get_running_loop()
+    return loop.run_in_executor(_EXECUTOR, lambda: func(*args, **kwargs))

--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -11,6 +11,8 @@ from typing import Any, Dict, List, Tuple
 import asyncio
 import logging
 import openai
+from .openai_async import run_async
+from .local_audio import tts_local, stt_local
 from .utils import retry_with_backoff
 
 
@@ -19,6 +21,11 @@ logger = logging.getLogger(__name__)
 
 def fast_transcribe(path_or_bytes, client, stt_model: str, lang_hint: str | None = None) -> str:
     """Perform a single transcription call with optional language hint."""
+    if stt_model == "local":
+        p = Path(path_or_bytes) if isinstance(path_or_bytes, (str, Path)) else Path("temp.wav")
+        if not isinstance(path_or_bytes, (str, Path)):
+            p.write_bytes(path_or_bytes)
+        return stt_local(p, lang_hint or "it")
     kwargs: Dict[str, Any] = {}
     if lang_hint in ("it", "en"):
         kwargs["language"] = lang_hint
@@ -52,6 +59,11 @@ def transcribe(
     ``lang_hint`` forza la lingua ("it" o "en") migliorando l'accuratezza
     della trascrizione quando la lingua di conversazione è nota.
     """
+    if stt_model == "local":
+        p = Path(path_or_bytes) if isinstance(path_or_bytes, (str, Path)) else Path("temp.wav")
+        if not isinstance(path_or_bytes, (str, Path)):
+            p.write_bytes(path_or_bytes)
+        return stt_local(p, lang_hint or "it"), lang_hint or ""
     try:
         kwargs: Dict[str, Any] = {
             "model": stt_model,
@@ -178,7 +190,7 @@ async def oracle_answer_async(
     mode: str = "detailed",
 ) -> Tuple[str, List[Dict[str, Any]]]:
     """Asynchronous wrapper around :func:`oracle_answer`."""
-    return await asyncio.to_thread(
+    return await run_async(
         oracle_answer,
         question,
         lang_hint,
@@ -195,6 +207,10 @@ async def oracle_answer_async(
 
 def synthesize(text: str, out_path: Path, client, tts_model: str, tts_voice: str) -> None:
     logger.info("🎧 Sintesi vocale…")
+    if tts_model == "local":
+        tts_local(text, out_path)
+        logger.info("✅ Audio → %s", out_path.name)
+        return
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
     def do_call() -> Path:
@@ -225,7 +241,7 @@ async def synthesize_async(
     text: str, out_path: Path, client, tts_model: str, tts_voice: str
 ) -> None:
     """Asynchronously run :func:`synthesize` in a thread."""
-    await asyncio.to_thread(synthesize, text, out_path, client, tts_model, tts_voice)
+    await run_async(synthesize, text, out_path, client, tts_model, tts_voice)
 
 
 def export_audio_answer(

--- a/OcchioOnniveggente/src/retrieval.py
+++ b/OcchioOnniveggente/src/retrieval.py
@@ -7,6 +7,12 @@ from pathlib import Path
 from typing import List, Dict, Tuple, Iterable, Optional, Any
 import numpy as np
 
+try:
+    from .metadata_store import MetadataStore
+except Exception:  # pragma: no cover - optional
+    MetadataStore = None  # type: ignore
+
+
 # Prova librerie migliori, ma non sono obbligatorie
 try:
     from rank_bm25 import BM25Okapi  # pip install rank-bm25
@@ -252,7 +258,7 @@ def retrieve(
     embed_model: str | None = None,
     rewrite_model: str | None = None,
     rerank_model: str | None = None,
-) -> List[Dict]:
+    store: Any | None = None) -> List[Dict]:
     """Hybrid BM25 + embedding retrieval returning metadata for citations."""
     if client is not None and rewrite_model:
         try:
@@ -262,7 +268,10 @@ def retrieve(
         except Exception:
             pass
 
-    docs = _load_index(docstore_path)
+    if store is not None:
+        docs = store.get_documents() if hasattr(store, "get_documents") else []
+    else:
+        docs = _load_index(docstore_path)
     if topic:
         tnorm = str(topic).lower()
         docs = [d for d in docs if str(d.get("topic", "")).lower() == tnorm]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ OcchioOnniveggente/
 ├── DataBase/         # archivio documenti indicizzati
 └── tests/            # test automatici (pytest)
 ```
+## Aggiornamenti backend
+
+- **MetadataStore**: nuovo archivio dei metadati basato su SQLite FTS o PostgreSQL, con supporto opzionale al vector store FAISS.
+- Le chiamate OpenAI pesanti possono ora essere eseguite in un thread pool tramite `openai_async.run_async`, evitando blocchi dell'applicazione.
+- Funzioni TTS/STT locali con utilità di streaming a chunk in `local_audio.py`.
+
 
 ---
 
@@ -185,6 +191,7 @@ python scripts/ingest_docs.py --reindex
 python scripts/ingest_docs.py --clear
 ```
 
+Lo script `scripts/ingest_docs.py` ora rileva automaticamente un percorso con estensione `.db` o un DSN (`sqlite:///` o `postgresql://`) e utilizza il nuovo `MetadataStore` con indice FTS.
 Il percorso dell'indice è configurabile con `docstore_path` in `settings.yaml`.
 Prima di `--remove`, `--clear` o `--reindex` lo script crea un backup
 `index.json.bak`. Per ripristinare l'indice basta copiare il file di backup

--- a/tests/test_metadata_store.py
+++ b/tests/test_metadata_store.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+from src.metadata_store import MetadataStore
+
+
+def test_metadata_store_search(tmp_path: Path) -> None:
+    db_path = tmp_path / "docs.db"
+    store = MetadataStore(str(db_path))
+    store.add_documents([
+        {"id": "doc1", "text": "Questo è un test"},
+        {"id": "doc2", "text": "La frase chiave è qui"},
+    ])
+    results = store.search("frase")
+    assert results and results[0][0] == "doc2"
+    # get_documents should return both entries
+    docs = store.get_documents()
+    assert any(d["id"] == "doc1" for d in docs)
+    store.delete_documents(["doc1"])
+    docs = store.get_documents()
+    assert all(d["id"] != "doc1" for d in docs)


### PR DESCRIPTION
## Summary
- add MetadataStore with SQLite FTS/optional PostgreSQL and FAISS vector index
- run heavy OpenAI calls in shared thread pool and allow local TTS/STT
- allow ingest/retrieval to use MetadataStore and document new backend features

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acc4d8009083278397ce26f8cd67fa