### PR TITLE
docs: wrap logging utils description

### DIFF
--- a/OcchioOnniveggente/src/logging_utils.py
+++ b/OcchioOnniveggente/src/logging_utils.py
@@ -1,4 +1,5 @@
-"""Utility per la configurazione del logging strutturato.
+"""
+Utility per la configurazione del logging strutturato.
 
 Il modulo imposta un logging asincrono basato su ``QueueListener`` e
 ``RotatingFileHandler``. I messaggi vengono serializzati in JSON e


### PR DESCRIPTION
## Summary
- wrap initial description in logging_utils with a proper triple-quoted docstring

## Testing
- `python -m pytest` *(fails: AttributeError: 'NoneType' object has no attribute 'get')*

------
https://chatgpt.com/codex/tasks/task_e_68accd88dc008327a26dbfada00f935e