### PR TITLE
feat: make OpenAI thread pool size configurable

### DIFF
--- a/OcchioOnniveggente/settings.yaml
+++ b/OcchioOnniveggente/settings.yaml
@@ -17,6 +17,10 @@ openai:
   # (usato da src/domain.py se abilitato)
   embed_model: text-embedding-3-large   # opzionale; se mancante, niente embeddings
 
+  # Numero massimo di thread per le chiamate OpenAI
+  # Può essere sovrascritto con la variabile d'ambiente ORACOLO_MAX_WORKERS
+  max_workers: 4
+
 audio:
   # Audio I/O e file temporanei
   sample_rate: 24000

--- a/OcchioOnniveggente/src/openai_async.py
+++ b/OcchioOnniveggente/src/openai_async.py
@@ -2,19 +2,43 @@ from __future__ import annotations
 
 """Utilities to offload expensive OpenAI calls to a thread pool."""
 
-from concurrent.futures import Future
+from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Callable, TypeVar, Any
 import asyncio
+import os
+import atexit
 
 from .service_container import container
 
 T = TypeVar("T")
 
+_executor: ThreadPoolExecutor | None = None
+
+
+def _get_max_workers() -> int:
+    """Return the desired worker count from env or settings."""
+    env_value = os.getenv("ORACOLO_MAX_WORKERS")
+    if env_value:
+        try:
+            return int(env_value)
+        except ValueError:
+            pass
+    return container.settings.openai.max_workers
+
+
+def _executor_instance() -> ThreadPoolExecutor:
+    """Lazily create a thread pool executor."""
+    global _executor
+    if _executor is None:
+        _executor = ThreadPoolExecutor(max_workers=_get_max_workers())
+        atexit.register(_executor.shutdown)
+    return _executor
+
 
 def submit(func: Callable[..., T], *args: Any, **kwargs: Any) -> Future:
     """Submit ``func`` to the shared executor and return a :class:`Future`."""
 
-    return container.executor().submit(func, *args, **kwargs)
+    return _executor_instance().submit(func, *args, **kwargs)
 
 
 def run(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
@@ -27,4 +51,4 @@ def run_async(func: Callable[..., T], *args: Any, **kwargs: Any) -> asyncio.Futu
     """Awaitable version of :func:`run` using ``asyncio`` integration."""
 
     loop = asyncio.get_running_loop()
-    return loop.run_in_executor(container.executor(), lambda: func(*args, **kwargs))
+    return loop.run_in_executor(_executor_instance(), lambda: func(*args, **kwargs))

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ OcchioOnniveggente/
 ## Aggiornamenti backend
 
 - **MetadataStore**: nuovo archivio dei metadati basato su SQLite FTS o PostgreSQL, con supporto opzionale al vector store FAISS.
-- Le chiamate OpenAI pesanti possono ora essere eseguite in un thread pool tramite `openai_async.run_async`, evitando blocchi dell'applicazione.
+- Le chiamate OpenAI pesanti possono ora essere eseguite in un thread pool tramite `openai_async.run_async`, evitando blocchi dell'applicazione. Il numero di thread è configurabile via `openai.max_workers` o variabile d'ambiente `ORACOLO_MAX_WORKERS`.
 - Funzioni TTS/STT locali con utilità di streaming a chunk in `local_audio.py`.
 
 


### PR DESCRIPTION
## Summary
- allow OpenAI calls to run in a thread pool sized via `ORACOLO_MAX_WORKERS` or `openai.max_workers`
- document new `max_workers` option in settings and README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acce7573648327b95f7029d0ff1305