### PR TITLE
Add executor shutdown handling for OpenAI async operations

### DIFF
--- a/OcchioOnniveggente/src/openai_async.py
+++ b/OcchioOnniveggente/src/openai_async.py
@@ -2,19 +2,32 @@ from __future__ import annotations
 
 """Utilities to offload expensive OpenAI calls to a thread pool."""
 
-from concurrent.futures import Future
+from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Callable, TypeVar, Any
 import asyncio
+import atexit
 
-from .service_container import container
+from .config import Settings
 
 T = TypeVar("T")
+
+_EXECUTOR: ThreadPoolExecutor | None = None
+
+
+def _get_executor() -> ThreadPoolExecutor:
+    """Lazily create the shared executor."""
+
+    global _EXECUTOR
+    if _EXECUTOR is None:
+        workers = Settings().openai.max_workers
+        _EXECUTOR = ThreadPoolExecutor(max_workers=workers)
+    return _EXECUTOR
 
 
 def submit(func: Callable[..., T], *args: Any, **kwargs: Any) -> Future:
     """Submit ``func`` to the shared executor and return a :class:`Future`."""
 
-    return container.executor().submit(func, *args, **kwargs)
+    return _get_executor().submit(func, *args, **kwargs)
 
 
 def run(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
@@ -27,4 +40,16 @@ def run_async(func: Callable[..., T], *args: Any, **kwargs: Any) -> asyncio.Futu
     """Awaitable version of :func:`run` using ``asyncio`` integration."""
 
     loop = asyncio.get_running_loop()
-    return loop.run_in_executor(container.executor(), lambda: func(*args, **kwargs))
+    return loop.run_in_executor(_get_executor(), lambda: func(*args, **kwargs))
+
+
+def shutdown() -> None:
+    """Shutdown the shared executor."""
+
+    global _EXECUTOR
+    if _EXECUTOR is not None:
+        _EXECUTOR.shutdown(wait=True)
+        _EXECUTOR = None
+
+
+atexit.register(shutdown)

--- a/OcchioOnniveggente/src/service_container.py
+++ b/OcchioOnniveggente/src/service_container.py
@@ -18,6 +18,7 @@ import openai
 
 from .config import Settings, get_openai_api_key
 from .ui_state import UIState
+from . import openai_async
 
 
 @dataclass
@@ -54,7 +55,13 @@ class ServiceContainer:
             self._executor.shutdown(wait=True)
             self._executor = None
 
+    def close(self) -> None:
+        """Shutdown all services including async helpers."""
+
+        self.shutdown()
+        openai_async.shutdown()
+
 
 # Default container used by the application
 container = ServiceContainer()
-atexit.register(container.shutdown)
+atexit.register(container.close)


### PR DESCRIPTION
## Summary
- introduce thread pool management in `openai_async` with global executor and `shutdown`
- add `ServiceContainer.close` to invoke async shutdown on exit

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acce79cda88327af0ac76c7bd4a660