### PR TITLE
Fix executor setup and indentation in openai_async

### DIFF
--- a/OcchioOnniveggente/src/openai_async.py
+++ b/OcchioOnniveggente/src/openai_async.py
@@ -7,39 +7,29 @@ from typing import Callable, TypeVar, Any
 import asyncio
 import os
 import atexit
+
 from .config import Settings
+
 
 T = TypeVar("T")
 
-
-_EXECUTOR: ThreadPoolExecutor | None = None
-
-
-def _get_executor() -> ThreadPoolExecutor:
-    """Lazily create the shared executor."""
-
-    global _EXECUTOR
-    if _EXECUTOR is None:
-        workers = Settings().openai.max_workers
-        _EXECUTOR = ThreadPoolExecutor(max_workers=workers)
-    return _EXECUTOR
-
+# Shared executor instance
 _executor: ThreadPoolExecutor | None = None
 
 
 def _get_max_workers() -> int:
-    """Return the desired worker count from env or settings."""
+    """Return desired worker count from env or settings."""
     env_value = os.getenv("ORACOLO_MAX_WORKERS")
     if env_value:
         try:
             return int(env_value)
         except ValueError:
             pass
-    return container.settings.openai.max_workers
+    return Settings().openai.max_workers
 
 
-def _executor_instance() -> ThreadPoolExecutor:
-    """Lazily create a thread pool executor."""
+def _get_executor() -> ThreadPoolExecutor:
+    """Lazily create the shared executor."""
     global _executor
     if _executor is None:
         _executor = ThreadPoolExecutor(max_workers=_get_max_workers())
@@ -47,41 +37,28 @@ def _executor_instance() -> ThreadPoolExecutor:
     return _executor
 
 
-
 def submit(func: Callable[..., T], *args: Any, **kwargs: Any) -> Future:
-    """Submit ``func`` to the shared executor and return a :class:`Future`."""
-
-
+    """Submit ``func`` to the shared executor and return a Future."""
     return _get_executor().submit(func, *args, **kwargs)
-
-    return _executor_instance().submit(func, *args, **kwargs)
-
 
 
 def run(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
     """Run ``func`` synchronously in the executor and wait for the result."""
-
     return submit(func, *args, **kwargs).result()
 
 
 def run_async(func: Callable[..., T], *args: Any, **kwargs: Any) -> asyncio.Future:
     """Awaitable version of :func:`run` using ``asyncio`` integration."""
-
     loop = asyncio.get_running_loop()
-
     return loop.run_in_executor(_get_executor(), lambda: func(*args, **kwargs))
 
 
 def shutdown() -> None:
     """Shutdown the shared executor."""
-
-    global _EXECUTOR
-    if _EXECUTOR is not None:
-        _EXECUTOR.shutdown(wait=True)
-        _EXECUTOR = None
+    global _executor
+    if _executor is not None:
+        _executor.shutdown(wait=True)
+        _executor = None
 
 
 atexit.register(shutdown)
-
-    return loop.run_in_executor(_executor_instance(), lambda: func(*args, **kwargs))
- main


### PR DESCRIPTION
## Summary
- clean up `openai_async` module with a single lazily-initialized executor
- support `ORACOLO_MAX_WORKERS` env override and proper shutdown hook

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acd5e576488327bcfe02e6c200577a