### PR TITLE
Remove redundant returns in cache_set and add Redis write test

### DIFF
--- a/OcchioOnniveggente/src/cache.py
+++ b/OcchioOnniveggente/src/cache.py
@@ -45,11 +45,6 @@ def cache_set(key: str, value: str, *, ex: int = 3600) -> None:
     if _cache is None:
         return
 
-
-        return None
-        return
-
-
     _safe_call(_cache.set, key, value, ex=ex)  # type: ignore[arg-type]
 
 

--- a/tests/test_cache_module.py
+++ b/tests/test_cache_module.py
@@ -1,0 +1,14 @@
+from OcchioOnniveggente.src import cache
+
+class DummyCache:
+    def __init__(self):
+        self.store = {}
+    def set(self, key, value, ex=None):
+        self.store[key] = (value, ex)
+
+
+def test_cache_set_writes_when_cache_available(monkeypatch):
+    dummy = DummyCache()
+    monkeypatch.setattr(cache, "_cache", dummy)
+    cache.cache_set("foo", "bar", ex=123)
+    assert dummy.store["foo"] == ("bar", 123)


### PR DESCRIPTION
## Summary
- simplify `cache_set` by removing unreachable `return` statements
- test that `cache_set` stores values when Redis cache is available

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acd8d845908327a972355236d4753d