### PR TITLE
Handle missing OpenAI API key before launching app

### DIFF
--- a/OcchioOnniveggente/src/main.py
+++ b/OcchioOnniveggente/src/main.py
@@ -87,7 +87,15 @@ def main() -> None:
         SET = Settings()
 
     api_key = get_openai_api_key(SET)
-    client = OpenAI(api_key=api_key) if api_key else OpenAI()
+    if not api_key:
+        print(
+            "❌ È necessaria una API key OpenAI.\n"
+            "   Imposta la variabile d'ambiente OPENAI_API_KEY"
+            " oppure aggiungi openai.api_key a settings.yaml."
+        )
+        return
+
+    client = OpenAI(api_key=api_key)
 
     session_profile_name, _ = get_active_profile(raw_settings)
 


### PR DESCRIPTION
## Summary
- exit gracefully when no OpenAI API key is available and provide instructions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acdec4fb288327b5d814b214c59e70