### PR TITLE
fix: persist OpenAI key from settings dialog

### DIFF
--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -2228,6 +2228,10 @@ class OracoloUI(tk.Tk):
             )
             if openai_conf["api_key"]:
                 self.chat_entry.configure(state="normal")
+            self.controller.save_settings(self._append_log)
+            self.base_settings = self.controller.base_settings
+            self.local_settings = self.controller.local_settings
+            self.settings = self.controller.settings
             win.destroy()
 
         ttk.Button(win, text="OK", command=on_ok).grid(row=len(rows), column=0, columnspan=2, pady=10)


### PR DESCRIPTION
## Summary
- Save OpenAI settings when closing the OpenAI dialog
- Refresh in-memory settings after saving so updated API key is used

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ace15a914883278310bc71765ed879