### PR TITLE
Add neon-styled QML desktop UI

### DIFF
--- a/OcchioOnniveggente/src/qml/MainSciFi.qml
+++ b/OcchioOnniveggente/src/qml/MainSciFi.qml
@@ -1,0 +1,139 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import Theme 1.0
+import "components"
+
+Window {
+    id: root
+    width: 1100
+    height: 700
+    visible: true
+    color: Theme.bg
+    title: "Occhio Onniveggente"
+
+    NeonPanel {
+        id: frame
+        anchors.fill: parent
+        anchors.margins: 24
+
+        Column {
+            anchors.fill: parent
+            anchors.margins: 24
+            spacing: 24
+
+            Row {
+                id: topBar
+                spacing: 30
+                anchors.horizontalCenter: parent.horizontalCenter
+                NeonTabButton { text: "DOCUMENTI" }
+                NeonTabButton { text: "IMPOSTAZIONI" }
+                NeonTabButton { text: "STRUMENTI" }
+                NeonTabButton { text: "SERVER" }
+                NeonTabButton { text: "LOG" }
+            }
+
+            Row {
+                id: mainRow
+                spacing: 24
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.top: topBar.bottom
+                anchors.bottom: parent.bottom
+
+                NeonPanel {
+                    id: leftPanel
+                    width: parent.width * 0.45
+                    anchors.top: parent.top
+                    anchors.bottom: parent.bottom
+
+                    Column {
+                        anchors.fill: parent
+                        anchors.margins: 24
+                        spacing: 24
+                        anchors.verticalCenter: parent.verticalCenter
+                        NeonOrb {
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            width: 220
+                            height: 220
+                        }
+                        Waveform {
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            width: 260
+                            height: 60
+                        }
+                        NeonIconButton {
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            iconText: "\uD83C\uDFA4" // microphone emoji
+                            onClicked: Bridge.onMicTapped()
+                        }
+                        Text {
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            text: "WAKE WORD RECOGNIZED"
+                            font.family: Theme.font
+                            font.pixelSize: 12
+                            color: Bridge.wakeWordRecognized ? Theme.neonA : Theme.textSoft
+                        }
+                    }
+                }
+
+                NeonPanel {
+                    id: rightPanel
+                    anchors.top: parent.top
+                    anchors.bottom: parent.bottom
+                    width: parent.width * 0.55
+
+                    Column {
+                        anchors.fill: parent
+                        anchors.margins: 16
+                        spacing: 12
+
+                        Flickable {
+                            id: chatView
+                            anchors.left: parent.left
+                            anchors.right: parent.right
+                            anchors.top: parent.top
+                            anchors.bottom: inputRow.top
+                            contentWidth: width
+                            clip: true
+                            Column {
+                                id: chatColumn
+                                width: chatView.width
+                                spacing: 10
+                                ChatBubble { text: "Quali sono gli orari di apertura?"; fromUser: true }
+                                ChatBubble { text: "Certamente. Gli orari di apertura del museo sono dal martedì alla domenica, dalle 9:00 alle 19:00, il lunedì siamo chiusi."; fromUser: false }
+                            }
+                        }
+
+                        Row {
+                            id: inputRow
+                            width: parent.width
+                            spacing: 8
+                            TextField {
+                                id: inputField
+                                width: parent.width - sendButton.width - 8
+                                color: Theme.text
+                                placeholderText: "Scrivi..."
+                                placeholderTextColor: Theme.textSoft
+                                font.family: Theme.font
+                                background: Rectangle {
+                                    color: Theme.panel
+                                    radius: Theme.radius
+                                    border.color: Theme.border
+                                    border.width: Theme.borderW
+                                }
+                            }
+                            NeonIconButton {
+                                id: sendButton
+                                width: 56
+                                height: 56
+                                iconText: "\u27A4"
+                                onClicked: Bridge.onSendPressed()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/OcchioOnniveggente/src/qml/Theme.qml
+++ b/OcchioOnniveggente/src/qml/Theme.qml
@@ -1,0 +1,18 @@
+pragma Singleton
+import QtQuick 2.15
+
+QtObject {
+    // Palette ispirata allo screenshot
+    readonly property color bg:          "#0b0f1a"
+    readonly property color panel:       "#0f1422"
+    readonly property color border:      "#1a2640"
+    readonly property color neonA:       "#31d3ff"   // ciano
+    readonly property color neonB:       "#a855f7"   // viola
+    readonly property color text:        "#9fe8ff"
+    readonly property color textSoft:    "#79b7c9"
+    readonly property color bubbleUser:  "#0f1b2e"
+    readonly property color bubbleBot:   "#0f2530"
+    readonly property real  radius:      18
+    readonly property real  borderW:     1.5
+    readonly property string font:       "Inter"
+}

--- a/OcchioOnniveggente/src/qml/components/ChatBubble.qml
+++ b/OcchioOnniveggente/src/qml/components/ChatBubble.qml
@@ -1,0 +1,25 @@
+import QtQuick 2.15
+import Theme 1.0
+
+Rectangle {
+    id: root
+    property bool fromUser: false
+    property string text: ""
+    color: fromUser ? Theme.bubbleUser : Theme.bubbleBot
+    radius: Theme.radius
+    border.color: Theme.border
+    border.width: Theme.borderW
+    width: parent ? parent.width * 0.9 : 300
+    x: fromUser && parent ? parent.width - width : 0
+
+    Text {
+        id: label
+        text: root.text
+        wrapMode: Text.Wrap
+        anchors.fill: parent
+        anchors.margins: 12
+        color: Theme.text
+        font.family: Theme.font
+        font.pixelSize: 14
+    }
+}

--- a/OcchioOnniveggente/src/qml/components/NeonIconButton.qml
+++ b/OcchioOnniveggente/src/qml/components/NeonIconButton.qml
@@ -1,0 +1,29 @@
+import QtQuick 2.15
+import Theme 1.0
+
+Rectangle {
+    id: root
+    property string iconText: ""
+    signal clicked
+    width: 56
+    height: 56
+    radius: width/2
+    color: Theme.panel
+    border.color: Theme.neonA
+    border.width: Theme.borderW
+
+    Text {
+        id: icon
+        text: root.iconText
+        anchors.centerIn: parent
+        color: Theme.neonA
+        font.pixelSize: 24
+        font.family: Theme.font
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        onClicked: root.clicked()
+        hoverEnabled: true
+    }
+}

--- a/OcchioOnniveggente/src/qml/components/NeonOrb.qml
+++ b/OcchioOnniveggente/src/qml/components/NeonOrb.qml
@@ -1,0 +1,15 @@
+import QtQuick 2.15
+import Theme 1.0
+
+Rectangle {
+    id: orb
+    width: 200
+    height: 200
+    radius: width/2
+    gradient: Gradient {
+        GradientStop { position: 0.0; color: Theme.neonA }
+        GradientStop { position: 1.0; color: Theme.neonB }
+    }
+    border.color: Theme.neonA
+    border.width: Theme.borderW
+}

--- a/OcchioOnniveggente/src/qml/components/NeonPanel.qml
+++ b/OcchioOnniveggente/src/qml/components/NeonPanel.qml
@@ -1,0 +1,11 @@
+import QtQuick 2.15
+import Theme 1.0
+
+Rectangle {
+    id: root
+    color: Theme.panel
+    radius: Theme.radius
+    border.color: Theme.border
+    border.width: Theme.borderW
+    anchors.margins: 0
+}

--- a/OcchioOnniveggente/src/qml/components/NeonTabButton.qml
+++ b/OcchioOnniveggente/src/qml/components/NeonTabButton.qml
@@ -1,0 +1,17 @@
+import QtQuick 2.15
+import Theme 1.0
+
+Text {
+    id: root
+    text: "TAB"
+    signal clicked
+    color: mouse.hovered ? Theme.neonA : Theme.text
+    font.family: Theme.font
+    font.pixelSize: 16
+    MouseArea {
+        id: mouse
+        anchors.fill: parent
+        hoverEnabled: true
+        onClicked: root.clicked()
+    }
+}

--- a/OcchioOnniveggente/src/qml/components/Waveform.qml
+++ b/OcchioOnniveggente/src/qml/components/Waveform.qml
@@ -1,0 +1,22 @@
+import QtQuick 2.15
+import Theme 1.0
+
+Canvas {
+    id: root
+    onPaint: {
+        var ctx = getContext("2d");
+        ctx.reset();
+        ctx.lineWidth = 2;
+        ctx.strokeStyle = Theme.neonA;
+        ctx.beginPath();
+        var h = height / 2;
+        for (var x = 0; x < width; x++) {
+            var y = h + Math.sin(x / width * Math.PI * 2) * (h - 4);
+            if (x === 0)
+                ctx.moveTo(x, y);
+            else
+                ctx.lineTo(x, y);
+        }
+        ctx.stroke();
+    }
+}

--- a/OcchioOnniveggente/src/ui_qml.py
+++ b/OcchioOnniveggente/src/ui_qml.py
@@ -1,93 +1,48 @@
-"""Qt/QML based UI for Occhio Onniveggente."""
+# -*- coding: utf-8 -*-
 from __future__ import annotations
-
-import json
 import sys
 from pathlib import Path
+from PySide6.QtCore import QObject, Slot, Signal, Property, QUrl
+from PySide6.QtGui import QGuiApplication
+from PySide6.QtQml import QQmlApplicationEngine
 
-from PySide6 import QtCore, QtQml
-from PySide6.QtWidgets import QApplication
+ROOT = Path(__file__).resolve().parent
 
-from src.ui_controller import UiController
+class Bridge(QObject):
+    wakeWordRecognizedChanged = Signal()
 
-
-class Backend(QtCore.QObject):
-    """Expose a minimal API to QML."""
-
-    def __init__(self, controller: UiController) -> None:
+    def __init__(self):
         super().__init__()
-        self.controller = controller
+        self._wake = False
 
-    @QtCore.Slot()
-    def start(self) -> None:
-        """Stub start command; hook real logic here."""
-        self.controller.reload_settings()
+    @Slot()
+    def onMicTapped(self):
+        print("🎙️ Mic tapped (TODO: start/stop capture)")
 
-    @QtCore.Slot()
-    def reload(self) -> None:
-        self.controller.reload_settings()
+    @Slot()
+    def onSendPressed(self):
+        print("💬 Send pressed (TODO: send text to backend)")
 
-    # ------------------------------------------------------------------
-    # Settings & documents helpers exposed to QML
+    @Property(bool, notify=wakeWordRecognizedChanged)
+    def wakeWordRecognized(self):
+        return self._wake
 
-    @QtCore.Slot(result="QVariantList")
-    def get_documents(self) -> list:
-        """Return the documents loaded from the configured docstore."""
-        path = self.controller.settings.get("docstore_path", "DataBase/index.json")
-        try:
-            data = json.loads(Path(path).read_text(encoding="utf-8"))
-        except Exception:
-            return []
+    @Slot(bool)
+    def setWakeWordRecognized(self, v: bool):
+        if self._wake != v:
+            self._wake = v
+            self.wakeWordRecognizedChanged.emit()
 
-        if isinstance(data, dict) and "documents" in data:
-            docs = data["documents"]
-        elif isinstance(data, list):
-            docs = data
-        else:
-            docs = []
-        return docs
-
-    @QtCore.Slot("QVariant", result="QVariant")
-    def update_rules(self, rules) -> list:
-        """Update domain rules/keywords in settings.
-
-        Parameters
-        ----------
-        rules: list | Any
-            Sequence of rule strings coming from QML.  If ``rules`` is a
-            comma separated string it will be split automatically.
-        """
-
-        dom = self.controller.settings.setdefault("domain", {})
-        if isinstance(rules, str):
-            items = [r.strip() for r in rules.split(",") if r.strip()]
-        else:
-            try:
-                items = [str(r).strip() for r in rules if str(r).strip()]
-            except Exception:
-                items = []
-
-        dom["keywords"] = items
-        return dom["keywords"]
-
-    @QtCore.Slot()
-    def save_config(self) -> None:
-        """Persist the current settings to disk."""
-        self.controller.save_settings()
-
-
-def main() -> int:
-    app = QApplication(sys.argv)
-    controller = UiController(Path(__file__).resolve().parent.parent)
-    backend = Backend(controller)
-    engine = QtQml.QQmlApplicationEngine()
-    engine.rootContext().setContextProperty("backend", backend)
-    qml_path = Path(__file__).resolve().parent / "qml" / "MainSciFi.qml"
-    engine.load(QtCore.QUrl.fromLocalFile(qml_path))
+def main():
+    app = QGuiApplication(sys.argv)
+    engine = QQmlApplicationEngine()
+    bridge = Bridge()
+    engine.rootContext().setContextProperty("Bridge", bridge)
+    engine.addImportPath(str(ROOT / "qml"))
+    engine.load(QUrl.fromLocalFile(str(ROOT / "qml" / "MainSciFi.qml")))
     if not engine.rootObjects():
-        return -1
-    return app.exec()
-
+        sys.exit(1)
+    sys.exit(app.exec())
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    main()


### PR DESCRIPTION
## Summary
- Replace `ui_qml.py` with minimal PySide6 bootstrap and Bridge
- Add neon themed QML scene with menu bar, orb panel, and chat panel
- Provide reusable components for panel, buttons, bubbles, waveform, and orb

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68acdded47dc83279e2a93c41a6a5dd9