### PR TITLE
feat: add optional audio preprocessing

### DIFF
--- a/OcchioOnniveggente/settings.yaml
+++ b/OcchioOnniveggente/settings.yaml
@@ -28,6 +28,8 @@ audio:
   input_wav: "data/temp/input.wav"
   output_wav: "data/temp/answer.wav"
   barge_rms_threshold: 0.25   # soglia RMS per barge-in (0..1)
+  denoise: true          # soppressione rumore/AGC
+  echo_cancel: false     # cancellazione eco
 
   # Selezione dispositivi audio
   # Metti l'indice numerico (es. 1) oppure una parte del nome (es. "USB Microphone").

--- a/OcchioOnniveggente/src/config.py
+++ b/OcchioOnniveggente/src/config.py
@@ -32,6 +32,8 @@ class AudioConfig(BaseModel):
     input_device: Optional[str | int] = None
     output_device: Optional[str | int] = None
     barge_rms_threshold: float = 0.25
+    denoise: bool = False
+    echo_cancel: bool = False
 
 
 class RecordingConfig(BaseModel):

--- a/OcchioOnniveggente/src/local_audio.py
+++ b/OcchioOnniveggente/src/local_audio.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Generator
 
+import numpy as np
+
+from .audio import AudioPreprocessor, load_audio_as_float
+from .config import Settings
+
 
 def stream_file(path: Path, chunk_size: int = 4096) -> Generator[bytes, None, None]:
     """Yield audio chunks from ``path`` for streaming playback."""
@@ -48,19 +53,23 @@ def tts_local(text: str, out_path: Path, lang: str = "it") -> None:
 
 
 def stt_local(audio_path: Path, lang: str = "it") -> str:
-    """Attempt a local transcription of ``audio_path``.
-
-    The function uses `speech_recognition` with the PocketSphinx backend when
-    available.  It is intentionally simple and meant only as a latency saving
-    fallback.
-    """
+    """Attempt a local transcription of ``audio_path`` using a cleaned signal."""
 
     try:
         import speech_recognition as sr  # type: ignore
 
+        setts = Settings.model_validate_yaml(Path("settings.yaml"))
+        sr_cfg = setts.audio.sample_rate
+        pre = AudioPreprocessor(
+            sr_cfg,
+            denoise=getattr(setts.audio, "denoise", False),
+            echo_cancel=getattr(setts.audio, "echo_cancel", False),
+        )
+        y, sr_in = load_audio_as_float(audio_path, sr_cfg)
+        y = pre.process(y)
+        pcm = (np.clip(y, -1, 1) * 32767).astype(np.int16).tobytes()
+        audio = sr.AudioData(pcm, sr_in, 2)
         r = sr.Recognizer()
-        with sr.AudioFile(str(audio_path)) as source:
-            audio = r.record(source)
         try:
             return r.recognize_sphinx(audio, language=lang)
         except Exception:

--- a/OcchioOnniveggente/src/main.py
+++ b/OcchioOnniveggente/src/main.py
@@ -22,7 +22,7 @@ import logging
 
 from src.config import Settings, get_openai_api_key
 from src.filters import ProfanityFilter
-from src.audio import record_until_silence, play_and_pulse
+from src.audio import AudioPreprocessor, record_until_silence, play_and_pulse
 from src.lights import SacnLight, WledLight, color_from_text
 from src.oracle import (
     transcribe,
@@ -106,6 +106,11 @@ def main() -> None:
     AUDIO_SR = AUDIO_CONF.sample_rate
     INPUT_WAV = Path(AUDIO_CONF.input_wav)
     OUTPUT_WAV = Path(AUDIO_CONF.output_wav)
+    PREPROC = AudioPreprocessor(
+        AUDIO_SR,
+        denoise=getattr(AUDIO_CONF, "denoise", False),
+        echo_cancel=getattr(AUDIO_CONF, "echo_cancel", False),
+    )
     in_spec = AUDIO_CONF.input_device
     out_spec = AUDIO_CONF.output_device
     in_dev = pick_device(in_spec, "input")
@@ -305,6 +310,7 @@ def main() -> None:
                     debug=DEBUG and (not args.quiet),
                     input_device_id=in_dev,
                     tts_playing=is_tts_playing,
+                    preprocessor=PREPROC,
                 )
                 if not ok:
                     continue
@@ -414,6 +420,7 @@ def main() -> None:
                     debug=DEBUG and (not args.quiet),
                     input_device_id=in_dev,
                     tts_playing=is_tts_playing,
+                    preprocessor=PREPROC,
                 )
                 if not ok:
                     continue


### PR DESCRIPTION
## Summary
- add optional AudioPreprocessor backed by webrtc_audio_processing or rnnoise
- expose `audio.denoise` and `audio.echo_cancel` settings and pass cleaned audio to VAD recording
- apply preprocessing to local STT and realtime server before transcription

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ace6207a8c83278ea6b88e20ffd475