### PR TITLE
feat: detect and persist conversation language

### DIFF
--- a/OcchioOnniveggente/src/chat.py
+++ b/OcchioOnniveggente/src/chat.py
@@ -17,6 +17,7 @@ class ChatState:
     topic_locked: bool = False
     pinned: List[str] = field(default_factory=list)
     summary: str = ""
+    language: Optional[str] = None
     pinned_limit: int = 5
 
     def reset(self) -> None:


### PR DESCRIPTION
## Summary
- add language field to ChatState to store current conversation language
- introduce detect_language to auto-guess Italian or English from audio/text and reuse in transcribe

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ace62a30e0832781ed6215201bd58e