### PR TITLE
feat: add local whisper backend

### DIFF
--- a/OcchioOnniveggente/README.md
+++ b/OcchioOnniveggente/README.md
@@ -26,6 +26,7 @@ Un `settings.yaml` minimale potrebbe essere:
 
 ```yaml
 debug: true
+stt_backend: openai  # openai | whisper
 openai:
   stt_model: gpt-4o-mini-transcribe
 ```
@@ -37,6 +38,11 @@ domain:
   profile: "museo"  # profilo selezionato
   topic: ""        # contesto specifico opzionale
 ```
+
+Per utilizzare `stt_backend: whisper` sono necessari i modelli
+`faster-whisper`; per prestazioni ottimali è consigliata una GPU NVIDIA
+con almeno 4 GB di VRAM, altrimenti la trascrizione avviene via CPU con
+prestazioni inferiori.
 
 Se ad esempio `audio.sample_rate` contiene una stringa (`"ventiquattromila"`) invece di un
 numero, Pydantic segnalerà `Input should be a valid integer` e userà `24000`.

--- a/OcchioOnniveggente/requirements.txt
+++ b/OcchioOnniveggente/requirements.txt
@@ -18,6 +18,7 @@ fastapi>=0.110.0
 PySide6>=6.6
 PySide6-Addons>=6.6
 shiboken6>=6.6
+faster-whisper>=1.0.0
 
 # Observability
 prometheus-client>=0.20.0

--- a/OcchioOnniveggente/settings.yaml
+++ b/OcchioOnniveggente/settings.yaml
@@ -3,6 +3,9 @@
 # Log di debug (mostra device audio e info VAD)
 debug: false
 
+# Backend STT: "openai" per l'API, "whisper" per modelli locali (faster-whisper, richiede ~4GB VRAM)
+stt_backend: openai
+
 openai:
   # Modello per trascrizione audio (puoi usare anche "whisper-1")
   stt_model: gpt-4o-mini-transcribe

--- a/OcchioOnniveggente/src/config.py
+++ b/OcchioOnniveggente/src/config.py
@@ -133,6 +133,7 @@ class RealtimeConfig(BaseModel):
 
 class Settings(BaseModel):
     debug: bool = False
+    stt_backend: Literal["openai", "whisper"] = "openai"
     wakeword: Optional[str] = None
     openai: OpenAIConfig = OpenAIConfig()
     audio: AudioConfig = AudioConfig()

--- a/OcchioOnniveggente/src/local_audio.py
+++ b/OcchioOnniveggente/src/local_audio.py
@@ -50,10 +50,27 @@ def tts_local(text: str, out_path: Path, lang: str = "it") -> None:
 def stt_local(audio_path: Path, lang: str = "it") -> str:
     """Attempt a local transcription of ``audio_path``.
 
-    The function uses `speech_recognition` with the PocketSphinx backend when
-    available.  It is intentionally simple and meant only as a latency saving
-    fallback.
+    The function prefers the `faster-whisper` package, automatically
+    selecting GPU or CPU and using quantized models when available.  If the
+    library is missing it falls back to ``speech_recognition`` with the
+    PocketSphinx backend.  On failure an empty string is returned.
     """
+
+    try:
+        from faster_whisper import WhisperModel  # type: ignore
+
+        try:
+            import torch  # type: ignore
+
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+        except Exception:
+            device = "cpu"
+        compute_type = "int8_float16" if device == "cuda" else "int8"
+        model = WhisperModel("base", device=device, compute_type=compute_type)
+        segments, _ = model.transcribe(audio_path.as_posix(), language=lang, task="transcribe")
+        return "".join(seg.text for seg in segments).strip()
+    except Exception:
+        pass
 
     try:
         import speech_recognition as sr  # type: ignore

--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -29,7 +29,7 @@ def fast_transcribe(
     lang_hint: str | None = None,
 ) -> str | None:
     """Perform a single transcription call with optional language hint."""
-    if stt_model == "local":
+    if container.settings.stt_backend != "openai":
         p = Path(path_or_bytes) if isinstance(path_or_bytes, (str, Path)) else Path("temp.wav")
         if not isinstance(path_or_bytes, (str, Path)):
             p.write_bytes(path_or_bytes)
@@ -61,6 +61,7 @@ def transcribe(
     *,
     debug: bool = False,
     lang_hint: str | None = None,
+    backend: str | None = None,
 ) -> Tuple[str | None, str]:
     """Trascrive un percorso o dei ``bytes`` e restituisce testo e lingua.
 
@@ -68,7 +69,8 @@ def transcribe(
     della trascrizione quando la lingua di conversazione è nota.
     """
 
-    if stt_model == "local":
+    backend = backend or container.settings.stt_backend
+    if backend != "openai":
         p = Path(path_or_bytes) if isinstance(path_or_bytes, (str, Path)) else Path("temp.wav")
         if not isinstance(path_or_bytes, (str, Path)):
             p.write_bytes(path_or_bytes)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ pip install pytest                     # necessario per eseguire i test
 Servono inoltre:
 - **Python 3.10+**
 - Un'API key OpenAI (`OPENAI_API_KEY`)
+- (Opzionale) GPU NVIDIA con ≥4 GB di VRAM per usare modelli Whisper locali; in assenza viene usata la CPU (più lenta).
 
 ---
 
@@ -39,9 +40,13 @@ Esempio minimale di `settings.yaml`:
 
 ```yaml
 debug: true
+stt_backend: openai  # openai | whisper
 openai:
   stt_model: gpt-4o-mini-transcribe
 ```
+
+`stt_backend` permette di usare l'API (`openai`) oppure una trascrizione
+locale tramite `faster-whisper` (`whisper`).
 
 Per avviare con dispositivi audio diversi:
 


### PR DESCRIPTION
## Summary
- add `stt_backend` option and faster-whisper dependency
- implement local Whisper transcription with automatic GPU/CPU selection
- route `oracle.transcribe` through configured STT backend and document hardware needs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ace63bc94083278706255d3b9354f1