### PR TITLE
feat: add faster-whisper local transcription

### DIFF
--- a/OcchioOnniveggente/requirements.txt
+++ b/OcchioOnniveggente/requirements.txt
@@ -18,6 +18,7 @@ fastapi>=0.110.0
 PySide6>=6.6
 PySide6-Addons>=6.6
 shiboken6>=6.6
+faster-whisper>=1.0.0
 
 # Observability
 prometheus-client>=0.20.0

--- a/OcchioOnniveggente/src/local_audio.py
+++ b/OcchioOnniveggente/src/local_audio.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Generator
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 def stream_file(path: Path, chunk_size: int = 4096) -> Generator[bytes, None, None]:
@@ -66,4 +70,33 @@ def stt_local(audio_path: Path, lang: str = "it") -> str:
         except Exception:
             return ""
     except Exception:
+        return ""
+
+
+def stt_local_faster(
+    audio_path: Path,
+    lang: str = "it",
+    *,
+    device: str = "cpu",
+    compute_type: str = "int8",
+) -> str:
+    """Transcribe ``audio_path`` using ``faster-whisper`` if available.
+
+    ``device`` can be ``"cpu"`` or ``"cuda"``; ``compute_type`` controls the
+    precision used by the model.  On failure or missing dependencies an empty
+    string is returned.
+    """
+
+    try:
+        from faster_whisper import WhisperModel  # type: ignore
+    except Exception:
+        logger.warning("faster-whisper non disponibile, fallback a stt_local")
+        return stt_local(audio_path, lang)
+
+    try:
+        model = WhisperModel("base", device=device, compute_type=compute_type)
+        segments, _ = model.transcribe(str(audio_path), language=lang)
+        return "".join(seg.text for seg in segments).strip()
+    except Exception:
+        logger.error("Errore trascrizione locale con faster-whisper", exc_info=True)
         return ""

--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -14,7 +14,7 @@ import logging
 import tempfile
 import openai
 from .openai_async import run_async
-from .local_audio import tts_local, stt_local
+from .local_audio import tts_local, stt_local_faster
 from .utils import retry_with_backoff
 from .cache import cache_get_json, cache_set_json
 from .service_container import container
@@ -28,6 +28,8 @@ def fast_transcribe(
     client,
     stt_model: str,
     lang_hint: str | None = None,
+    *,
+    device: str = "cpu",
 ) -> str | None:
     """Perform a single transcription call with optional language hint."""
     tmp_path: Path | None = None
@@ -40,7 +42,7 @@ def fast_transcribe(
                     tmp.write(path_or_bytes)
                     tmp_path = Path(tmp.name)
                 p = tmp_path
-            return stt_local(p, lang_hint or "it")
+            return stt_local_faster(p, lang_hint or "it", device=device)
 
         kwargs: Dict[str, Any] = {}
         if lang_hint in ("it", "en"):
@@ -78,6 +80,7 @@ def transcribe(
     *,
     debug: bool = False,
     lang_hint: str | None = None,
+    device: str = "cpu",
 ) -> Tuple[str | None, str]:
     """Trascrive un percorso o dei ``bytes`` e restituisce testo e lingua.
 
@@ -95,7 +98,7 @@ def transcribe(
                     tmp.write(path_or_bytes)
                     tmp_path = Path(tmp.name)
                 p = tmp_path
-            return stt_local(p, lang_hint or "it"), lang_hint or ""
+            return stt_local_faster(p, lang_hint or "it", device=device), lang_hint or ""
         finally:
             if tmp_path:
                 try:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ black>=23.0.0
 isort>=5.10.1
 mypy>=1.0.0
 ruff>=0.1.0
+faster-whisper>=1.0.0


### PR DESCRIPTION
## Summary
- add `stt_local_faster` using faster-whisper with device and compute-type options
- route oracle transcription helpers through `stt_local_faster`
- declare faster-whisper dependency and handle missing library gracefully

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ace806e86c8327826801cb5ae6eb03