### PR TITLE
Add precision selection for local LLM backend

### DIFF
--- a/OcchioOnniveggente/src/config.py
+++ b/OcchioOnniveggente/src/config.py
@@ -26,6 +26,7 @@ class OpenAIConfig(BaseModel):
 
 class ComputeModuleConfig(BaseModel):
     device: Literal["auto", "cpu", "cuda"] = "auto"
+    precision: Literal["fp32", "fp16", "bf16", "int4"] = "fp16"
 
 
 class ComputeConfig(BaseModel):

--- a/OcchioOnniveggente/src/local_llm.py
+++ b/OcchioOnniveggente/src/local_llm.py
@@ -8,14 +8,18 @@ dependencies when the local backend is not used. It provides a single
 returns the generated text.
 """
 
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Literal
 
 # simple in-memory cache so that the model is loaded only once
-_MODEL_CACHE: dict[Tuple[str, str], Tuple[object, object]] = {}
+_MODEL_CACHE: dict[Tuple[str, str, str], Tuple[object, object]] = {}
 
 
-def _load_model(model_path: str, device: str) -> Tuple[object, object]:
-    """Load the model/tokenizer pair for the given path and device."""
+def _load_model(
+    model_path: str,
+    device: str,
+    precision: Literal["fp32", "fp16", "bf16", "int4"],
+) -> Tuple[object, object]:
+    """Load the model/tokenizer pair for the given path, device and precision."""
     try:
         from transformers import AutoModelForCausalLM, AutoTokenizer
         import torch
@@ -24,11 +28,32 @@ def _load_model(model_path: str, device: str) -> Tuple[object, object]:
             "transformers and torch are required for the local LLM backend"
         ) from exc
 
-    key = (model_path, device)
+    key = (model_path, device, precision)
     if key not in _MODEL_CACHE:
         tokenizer = AutoTokenizer.from_pretrained(model_path)
-        model = AutoModelForCausalLM.from_pretrained(model_path)
-        model.to(device)
+        if precision == "int4":
+            try:
+                AutoModelArgs = {
+                    "load_in_4bit": True,
+                    "device_map": "auto" if device != "cpu" else {"": "cpu"},
+                }
+                model = AutoModelForCausalLM.from_pretrained(
+                    model_path, **AutoModelArgs
+                )
+            except Exception as exc:  # pragma: no cover - bitsandbytes runtime
+                raise RuntimeError(
+                    "bitsandbytes is required for int4 precision"
+                ) from exc
+        else:
+            dtype = {
+                "fp32": torch.float32,
+                "fp16": torch.float16,
+                "bf16": torch.bfloat16,
+            }[precision]
+            model = AutoModelForCausalLM.from_pretrained(
+                model_path, torch_dtype=dtype
+            )
+            model.to(device)
         model.eval()
         _MODEL_CACHE[key] = (tokenizer, model)
     return _MODEL_CACHE[key]
@@ -40,6 +65,7 @@ def generate(
     model_path: str,
     device: str = "cpu",
     max_new_tokens: int = 256,
+    precision: Literal["fp32", "fp16", "bf16", "int4"] = "fp32",
 ) -> str:
     """Generate a response using a local model.
 
@@ -54,7 +80,7 @@ def generate(
     max_new_tokens:
         Number of tokens to generate.
     """
-    tokenizer, model = _load_model(model_path, device)
+    tokenizer, model = _load_model(model_path, device, precision)
 
     prompt = "\n".join(f"{m['role']}: {m['content']}" for m in messages)
     inputs = tokenizer(prompt, return_tensors="pt").to(model.device)

--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -51,7 +51,7 @@ async def fast_transcribe_async(
     """Perform a single transcription call with optional language hint."""
 
     if container.settings.stt_backend != "openai":
-
+        pass
 
     if stt_model == "local":
 
@@ -606,7 +606,10 @@ async def oracle_answer_async(
 
             try:
                 ans = local_llm.generate(
-                    messages, model_path=llm_model, device=llm_device
+                    messages,
+                    model_path=llm_model,
+                    device=llm_device,
+                    precision=container.settings.compute.llm.precision,
                 )
             except Exception as e:  # pragma: no cover - runtime dependent
                 logger.error("Errore LLM locale: %s", e, exc_info=True)

--- a/README.md
+++ b/README.md
@@ -21,10 +21,27 @@ OcchioOnniveggente/
 
 Per usare un modello eseguito in locale è possibile impostare `llm_backend: local`
 e indicare in `openai.llm_model` il percorso del modello. Il wrapper utilizza
-`transformers` (o `llama-cpp`) e richiede una GPU con almeno ~8 GB di VRAM per un
-modello da 7B quantizzato a 4‑bit. Modelli più grandi necessitano di maggiore
-memoria o di tecniche di quantizzazione appropriate. In caso di errore il
-sistema effettua automaticamente il fallback al backend OpenAI.
+`transformers` (o `llama-cpp`) e supporta diversi livelli di precisione per
+riduire il consumo di memoria.
+
+Requisiti indicativi:
+
+- **fp32/fp16/bf16** – precisione piena o a 16 bit, richiede una GPU con almeno
+  ~8‑16 GB di VRAM a seconda delle dimensioni del modello.
+- **int4** – quantizzazione a 4 bit tramite `bitsandbytes`, consente di eseguire
+  un modello 7B con ~4 GB di VRAM.
+
+La precisione si seleziona in `settings.yaml` tramite `compute.llm.precision`:
+
+```yaml
+compute:
+  llm:
+    device: cuda         # auto | cpu | cuda
+    precision: int4      # fp32 | fp16 | bf16 | int4
+```
+
+In caso di errore il sistema effettua automaticamente il fallback al backend
+OpenAI.
 
 
 ---


### PR DESCRIPTION
## Summary
- allow local_llm.generate to load models with fp32/fp16/bf16/int4 precision
- expose compute.llm.precision configuration option
- document precision settings and hardware requirements for local models

## Testing
- `pytest -q` *(fails: syntax errors in existing oracle and realtime_server modules)*
- `pytest tests/test_config.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68acf279f4248327b5193352c5eaf49f