### PR TITLE
chore: configure QML import paths for VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,9 @@
 {
     "files.exclude": {
         "**/build/**": true
-    }
+    },
+    "qml.importPaths": [
+        "C:/Qt/6.9.1/msvc2022_64/qml",
+        "${workspaceFolder}/OcchioOnniveggente/src/qml"
+    ]
 }


### PR DESCRIPTION
## Summary
- add QML import paths in VS Code settings

## Testing
- `pytest -q` *(fails: SyntaxError in `OcchioOnniveggente/src/oracle.py`)*

------
https://chatgpt.com/codex/tasks/task_e_68acf471c5f48327937c9be37d037739