### PR TITLE
feat: enable QMLLS ini generation

### DIFF
--- a/OcchioOnniveggente/CMakeLists.txt
+++ b/OcchioOnniveggente/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.16)
+project(OcchioOnniveggente LANGUAGES CXX)
+
+set(QT_QML_GENERATE_QMLLS_INI ON)
+
+find_package(Qt6 COMPONENTS Qml Quick REQUIRED)
+


### PR DESCRIPTION
## Summary
- add minimal CMakeLists enabling QML language server ini generation for Qt6 projects

## Testing
- `cmake ..` *(fails: could not find Qt6)*
- `cmake --build .` *(fails: No rule to make target 'Makefile')*


------
https://chatgpt.com/codex/tasks/task_e_68acf4a9c9f88327b142db38aae30969