### PR TITLE
Use is_wake for hotword validation

### DIFF
--- a/OcchioOnniveggente/src/main.py
+++ b/OcchioOnniveggente/src/main.py
@@ -33,7 +33,7 @@ from src.oracle import (
     extract_summary,
 )
 from src.domain import validate_question
-from src.hotword import is_wake, matches_hotword_text
+from src.hotword import is_wake
 from src.chat import ChatState
 from src.conversation import ConversationManager, DialogState
 from src.logging_utils import setup_logging
@@ -342,17 +342,19 @@ def main() -> None:
                 # prova trascrizione forzando IT/EN per maggiore robustezza
                 text_it = fast_transcribe(INPUT_WAV, client, STT_MODEL, lang_hint="it")
                 text_en = fast_transcribe(INPUT_WAV, client, STT_MODEL, lang_hint="en")
-                is_en = matches_hotword_text(text_en, WAKE_EN)
-                is_it = matches_hotword_text(text_it, WAKE_IT)
+                wake_it, lang_it = is_wake(text_it, WAKE_IT, WAKE_EN)
+                wake_en, lang_en = is_wake(text_en, WAKE_IT, WAKE_EN)
+                is_it = wake_it and lang_it == "it"
+                is_en = wake_en and lang_en == "en"
                 if session_lang in ("it", "en"):
                     text = text_en if session_lang == "en" else text_it
                 else:
-                    if is_en:
+                    if wake_en:
                         text = text_en
-                        session_lang = "en"
-                    elif is_it:
+                        session_lang = lang_en or "en"
+                    elif wake_it:
                         text = text_it
-                        session_lang = "it"
+                        session_lang = lang_it or "it"
                     else:
                         text = text_en or text_it
                         if text_en:
@@ -363,12 +365,12 @@ def main() -> None:
                 logging.info(
                     "Hotword riconosciuta: %s (lang=%s)", text, session_lang
                 )
-                if not (is_it or is_en):
+                if not (wake_it or wake_en):
                     if DEBUG:
                         say("…hotword non riconosciuta, continuo l'attesa.")
                     logging.info("Hotword non riconosciuta: %s", text)
                     continue
-                wake_lang = session_lang or ("en" if is_en and not is_it else "it")
+                wake_lang = session_lang or (lang_en if wake_en and not wake_it else "it")
 
                 dlg.transition(DialogState.AWAKE)
                 continue


### PR DESCRIPTION
## Summary
- replace `matches_hotword_text` with `is_wake` on Italian/English transcripts
- hotword considered valid if either `is_wake` call succeeds
- remove leftover import

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad05f40ed88327874799d8d982deda