### PR TITLE
Increase idle timeout to 60 seconds

### DIFF
--- a/OcchioOnniveggente/settings.yaml
+++ b/OcchioOnniveggente/settings.yaml
@@ -141,7 +141,7 @@ oracle_system: >
 wake:
   enabled: true           # usa la hotword; se metti false parla sempre (sconsigliato)
   single_turn: false      # dopo 1 risposta resta attivo finché c'è attività
-  idle_timeout: 50        # secondi di inattività prima di tornare a SLEEP
+  idle_timeout: 60        # secondi di inattività prima di tornare a SLEEP
 
   # Frasi riconosciute (tolleranti a maiuscole, punteggiatura, piccoli errori STT)
   it_phrases:

--- a/OcchioOnniveggente/src/config.py
+++ b/OcchioOnniveggente/src/config.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 class WakeConfig(BaseModel):
     enabled: bool = True
     single_turn: bool = False
-    idle_timeout: float = 50.0
+    idle_timeout: float = 60.0
     it_phrases: List[str] = Field(default_factory=lambda: ["ciao oracolo", "ehi oracolo", "salve oracolo", "ciao, oracolo"])
     en_phrases: List[str] = Field(default_factory=lambda: ["hello oracle", "hey oracle", "hi oracle", "hello, oracle"])
 

--- a/OcchioOnniveggente/src/conversation.py
+++ b/OcchioOnniveggente/src/conversation.py
@@ -15,7 +15,7 @@ class ConversationManager:
     track of dialogue state and processing turns.
     """
 
-    idle_timeout: float = 50.0
+    idle_timeout: float = 60.0
     chat: ChatState = field(default_factory=ChatState)
     dlg: DialogueManager = field(init=False)
     is_processing: bool = False

--- a/OcchioOnniveggente/src/main.py
+++ b/OcchioOnniveggente/src/main.py
@@ -187,7 +187,7 @@ def main() -> None:
     WAKE_EN = ["hello oracle", "hey oracle", "hi oracle", "hello, oracle"]
     WAKE_ENABLED = True
     WAKE_SINGLE_TURN = False
-    IDLE_TIMEOUT = 50.0  # secondi di inattività prima di tornare a SLEEP
+    IDLE_TIMEOUT = 60.0  # secondi di inattività prima di tornare a SLEEP
 
     try:
         if getattr(SET, "wake", None) is not None:

--- a/OcchioOnniveggente/src/realtime_oracolo.py
+++ b/OcchioOnniveggente/src/realtime_oracolo.py
@@ -213,7 +213,7 @@ async def _run(url: str, sr: int, barge_threshold: float) -> None:
         "barge_threshold": barge_threshold,
         "ducking": False,
     }
-    conv = ConversationManager(idle_timeout=50)
+    conv = ConversationManager(idle_timeout=60)
     conv.transition(DialogState.LISTENING)
 
     async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:

--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -1234,7 +1234,7 @@ class OracoloUI(tk.Tk):
 
     def _poll_idle(self) -> None:
         now = time.time()
-        timeout = self.settings.get("wake", {}).get("idle_timeout", 50)
+        timeout = self.settings.get("wake", {}).get("idle_timeout", 60)
         if now - self.last_activity > timeout:
             self.status_var.set("😴 Dormiente — dì Ciao Oracolo per riattivarmi")
         elif self.status_var.get().startswith("😴"):
@@ -2309,7 +2309,7 @@ class OracoloUI(tk.Tk):
         win.configure(bg=self._bg)
 
         wake = self.settings.setdefault("wake", {})
-        timeout_var = tk.IntVar(value=int(wake.get("idle_timeout", 50)))
+        timeout_var = tk.IntVar(value=int(wake.get("idle_timeout", 60)))
         it_var = tk.StringVar(value=", ".join(wake.get("it_phrases", [])))
         en_var = tk.StringVar(value=", ".join(wake.get("en_phrases", [])))
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ definire più **profili** preconfigurati. Ad esempio:
 wake:
   enabled: true
   single_turn: false
-  idle_timeout: 50
+  idle_timeout: 60
   it_phrases: ["ciao oracolo"]
 
 profiles:


### PR DESCRIPTION
## Summary
- Raise default idle timeout to 60s across the app
- Pass the updated timeout to `ConversationManager` and adjust config, UI, and realtime runner
- Update documentation and sample settings to mention the 60s interval

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad05fb579483278de74bf4ebb75905