### PR TITLE
Handle hotword prefix in transcribed questions

### DIFF
--- a/OcchioOnniveggente/src/main.py
+++ b/OcchioOnniveggente/src/main.py
@@ -33,7 +33,7 @@ from src.oracle import (
     extract_summary,
 )
 from src.domain import validate_question
-from src.hotword import is_wake, matches_hotword_text
+from src.hotword import is_wake, matches_hotword_text, strip_hotword_prefix
 from src.chat import ChatState
 from src.conversation import ConversationManager, DialogState
 from src.logging_utils import setup_logging
@@ -432,6 +432,9 @@ def main() -> None:
                     debug=DEBUG and (not args.quiet),
                     lang_hint=session_lang,
                 )
+                matched, remainder = strip_hotword_prefix(q, WAKE_IT + WAKE_EN)
+                if matched:
+                    q = remainder
                 say(f"📝 Domanda: {q}")
                 if not q:
                     continue

--- a/tests/test_hotword_prefix.py
+++ b/tests/test_hotword_prefix.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from OcchioOnniveggente.src.hotword import strip_hotword_prefix
+
+
+def test_strip_hotword_prefix_removes_match():
+    matched, remainder = strip_hotword_prefix(
+        "Ciao Oracolo, come stai?", ["ciao oracolo", "hello oracle"]
+    )
+    assert matched is True
+    assert remainder == "come stai?"
+
+
+def test_strip_hotword_prefix_no_match():
+    text = "Oggi, ciao oracolo, come va?"
+    matched, remainder = strip_hotword_prefix(text, ["ciao oracolo"])
+    assert matched is False
+    assert remainder == text


### PR DESCRIPTION
## Summary
- Strip any leading hotword phrases from questions after transcription in `main.py`
- Test `strip_hotword_prefix` to ensure hotword phrases are removed only when leading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad061776b483278bbe47e184323d53