### PR TITLE
feat: summarize conversation history

### DIFF
--- a/OcchioOnniveggente/src/main.py
+++ b/OcchioOnniveggente/src/main.py
@@ -135,10 +135,12 @@ def main() -> None:
 
     # Chat state
     CHAT_ENABLED = bool(getattr(getattr(SET, "chat", None), "enabled", False))
+    CHAT_TURNS = int(getattr(getattr(SET, "chat", None), "max_turns", 10))
+    CHAT_HISTORY_LIMIT = CHAT_TURNS * 2
 
     def _new_chat():
         return ChatState(
-            max_turns=int(getattr(getattr(SET, "chat", None), "max_turns", 10)),
+            max_turns=0,
             persist_jsonl=Path(
                 getattr(
                     getattr(SET, "chat", None),
@@ -269,6 +271,8 @@ def main() -> None:
             prof_name, prof = get_active_profile(CURRENT_CFG, session_profile_name)
             if CHAT_ENABLED:
                 chat = chat_histories[session_profile_name]
+                dlg.chat = chat
+                dlg.max_history = CHAT_HISTORY_LIMIT
             else:
                 chat = None
                 if not args.autostart:
@@ -477,12 +481,12 @@ def main() -> None:
                 pending_q = q
                 pending_lang = eff_lang
                 if CHAT_ENABLED and chat is not None:
-                    chat.push_user(q)
+                    dlg.push_user(q)
                     changed = chat.update_topic(q, client, EMB_MODEL)
                     if changed:
                         say("🔀 Cambio tema.")
                     pending_topic = chat.topic_text
-                    pending_history = chat.history
+                    pending_history = dlg.messages
                 else:
                     pending_topic = None
                     pending_history = None
@@ -540,7 +544,7 @@ def main() -> None:
 
                     pending_full_answer = pending_answer
                     if CHAT_ENABLED and chat is not None:
-                        chat.push_assistant(pending_full_answer)
+                        dlg.push_assistant(pending_full_answer)
                     if dlg.turn_id != processing_turn:
                         continue
                     dlg.transition(DialogState.SPEAKING)
@@ -569,7 +573,7 @@ def main() -> None:
                 )
                 pending_full_answer = pending_answer
                 if CHAT_ENABLED and chat is not None:
-                    chat.push_assistant(pending_full_answer)
+                    dlg.push_assistant(pending_full_answer)
                 pending_answer = extract_summary(pending_full_answer)
                 if dlg.turn_id != processing_turn:
                     continue

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from OcchioOnniveggente.src.conversation import ConversationManager
+
+
+def test_conversation_manager_tracks_and_summarizes():
+    cm = ConversationManager(max_history=4)
+    for i in range(6):
+        cm.push_user(f"u{i}")
+        cm.push_assistant(f"a{i}")
+    msgs = cm.messages
+    assert cm.chat.summary
+    assert msgs[0]["role"] == "system"
+    assert msgs[-1]["content"] == "a5"
+    assert len(msgs) <= cm.max_history + 1


### PR DESCRIPTION
## Summary
- track a limited sliding window of messages in `ConversationManager`
- expose conversation summary and recent history to LLM calls
- test conversation manager history trimming and summarization

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad073e507083278a0f7b1dd8e26e07