### PR TITLE
Add streaming token generation and CLI listener

### DIFF
--- a/OcchioOnniveggente/src/cli.py
+++ b/OcchioOnniveggente/src/cli.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import sys
+import time
+from typing import Iterator
+from threading import Event
 
 
 def _ensure_utf8_stdout() -> None:
@@ -16,6 +19,35 @@ def _ensure_utf8_stdout() -> None:
 def say(msg: str) -> None:
     """Print a message intended for the user conversation."""
     print(msg, flush=True)
+
+
+def stream_say(
+    tokens: Iterator[str], *, stop_event: Event | None = None, timeout: float | None = None
+) -> str:
+    """Print ``tokens`` as they are produced.
+
+    The function consumes the ``tokens`` iterator, printing each chunk as soon
+    as it becomes available.  It returns the accumulated text.  Streaming can
+    be interrupted either by setting ``stop_event`` or by pressing
+    ``Ctrl+C``/``KeyboardInterrupt``; a ``timeout`` in seconds can also be
+    provided to stop after a fixed duration.
+    """
+
+    text = ""
+    start = time.monotonic()
+    try:
+        for chunk in tokens:
+            if stop_event is not None and stop_event.is_set():
+                break
+            if timeout is not None and (time.monotonic() - start) > timeout:
+                break
+            text += chunk
+            print(chunk, end="", flush=True)
+    except KeyboardInterrupt:  # pragma: no cover - interactive usage
+        pass
+    finally:
+        print()
+    return text
 
 
 def oracle_greeting(lang: str) -> str:

--- a/README.md
+++ b/README.md
@@ -92,6 +92,28 @@ prestazioni su CPU rispetto all'uso diretto di PyTorch.
 In caso di errore il sistema effettua automaticamente il fallback al backend
 OpenAI.
 
+## Modalità streaming
+
+È possibile ricevere la risposta dell'LLM in tempo reale utilizzando la nuova
+funzione `stream_generate` in `src/oracle.py`. La funzione restituisce un
+iteratore che emette piccoli chunk di testo man mano che vengono prodotti dal
+modello, permettendo di aggiornare l'interfaccia senza attese.
+
+Esempio minimo in modalità testuale:
+
+```python
+from OcchioOnniveggente.src.oracle import stream_generate
+from OcchioOnniveggente.src.cli import stream_say
+from openai import OpenAI
+
+client = OpenAI()
+tokens = stream_generate("Ciao?", "it", client, "gpt-4o", "")
+stream_say(tokens)
+```
+
+Lo streaming può essere interrotto impostando un `threading.Event`, passando
+un parametro `timeout` oppure premendo `CTRL+C` nella CLI.
+
 
 ---
 


### PR DESCRIPTION
## Summary
- support synchronous streaming via new `stream_generate` helper
- print tokens in real time with `stream_say` including stop and timeout controls
- document streaming usage in README and add regression tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad073edcf48327961b08b9e11a76a2