### PR TITLE
feat: add speech synthesis and adaptive VAD

### DIFF
--- a/OcchioOnniveggente/README.md
+++ b/OcchioOnniveggente/README.md
@@ -29,6 +29,10 @@ debug: true
 stt_backend: openai  # openai | whisper
 openai:
   stt_model: gpt-4o-mini-transcribe
+  tts_voice: alloy
+recording:
+  use_webrtcvad: true
+  vad_sensitivity: 2
 ```
 
 Per limitare le risposte a un determinato contesto è possibile definire un profilo di dominio:

--- a/OcchioOnniveggente/requirements.txt
+++ b/OcchioOnniveggente/requirements.txt
@@ -19,6 +19,8 @@ PySide6>=6.6
 PySide6-Addons>=6.6
 shiboken6>=6.6
 faster-whisper>=1.0.0
+pyttsx3>=2.90
+webrtcvad>=2.0.10
 
 # Observability
 prometheus-client>=0.20.0

--- a/OcchioOnniveggente/settings.yaml
+++ b/OcchioOnniveggente/settings.yaml
@@ -89,6 +89,8 @@ recording:
   # NUOVO: soglia minima di ampiezza (0..1) per considerare valida una registrazione.
   # Se il picco audio è sotto questa soglia, la registrazione viene scartata come "silenzio".
   min_speech_level: 0.01
+  use_webrtcvad: true        # abilita VAD adattivo WebRTC
+  vad_sensitivity: 2         # 0=più sensibile, 3=più severo
 
 vad:
   # Parametri del VAD "a energia"

--- a/OcchioOnniveggente/src/audio.py
+++ b/OcchioOnniveggente/src/audio.py
@@ -142,7 +142,9 @@ def _record_with_webrtcvad(
     END_MS = int(recording_conf.get("end_ms", 800))
     MAX_MS = int(recording_conf.get("max_ms", 15000))
     MIN_SPEECH = float(recording_conf.get("min_speech_level", 0.01))
-    vad = webrtcvad.Vad(2)
+    mode = int(recording_conf.get("vad_sensitivity", 2))
+    mode = max(0, min(3, mode))
+    vad = webrtcvad.Vad(mode)
     path.parent.mkdir(parents=True, exist_ok=True)
     print(f"\n🎤 Parla pure (VAD webrtc, max {MAX_MS/1000:.1f}s)…")
     stream_kwargs = {"samplerate": sr, "blocksize": frame_samples, "channels": 1, "dtype": "int16"}
@@ -212,7 +214,7 @@ def record_until_silence(
     except Exception:
         pass
 
-    if recording_conf.get("use_webrtcvad") and webrtcvad is not None:
+    if recording_conf.get("use_webrtcvad", True) and webrtcvad is not None:
         return _record_with_webrtcvad(
             path, sr, recording_conf, input_device_id, tts_playing, preprocessor
         )

--- a/OcchioOnniveggente/src/config.py
+++ b/OcchioOnniveggente/src/config.py
@@ -61,7 +61,8 @@ class RecordingConfig(BaseModel):
     fallback_to_timed: bool = False
     min_speech_level: float = 0.02
     hold_off_after_tts_ms: int = 500
-    use_webrtcvad: bool = False
+    use_webrtcvad: bool = True
+    vad_sensitivity: int = 2
 
 
 class VadConfig(BaseModel):

--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -354,13 +354,38 @@ def synthesize(
     tts_model: str | None = None,
     tts_voice: str | None = None,
 ) -> None:
-    """Minimal TTS helper used by the UI.
+    """Synthesize ``text`` into ``out_path`` using a local TTS engine.
 
-    The function simply writes an empty file; the real project would call a TTS
-    backend.  It returns ``None`` to mirror the original signature.
+    The implementation favours ``pyttsx3`` for offline speech synthesis and
+    falls back to ``gTTS`` when available. If no backend can generate audio an
+    empty placeholder file is created so callers do not fail.
     """
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        import pyttsx3  # type: ignore
+
+        engine = pyttsx3.init()
+        if tts_voice:
+            try:
+                engine.setProperty("voice", tts_voice)
+            except Exception:
+                pass
+        engine.save_to_file(text, out_path.as_posix())
+        engine.runAndWait()
+        return
+    except Exception:
+        pass
+
+    try:
+        from gtts import gTTS  # type: ignore
+
+        gTTS(text=text, lang="it").save(out_path.as_posix())
+        return
+    except Exception:
+        pass
+
     out_path.write_bytes(b"")
 
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ pip install pytest                     # necessario per eseguire i test
 Servono inoltre:
 - **Python 3.10+**
 - Un'API key OpenAI (`OPENAI_API_KEY`)
+- Motore TTS locale `pyttsx3` e VAD adattivo `webrtcvad` inclusi in `requirements.txt`.
 - (Opzionale) GPU NVIDIA con ≥4 GB di VRAM per usare modelli Whisper locali; in assenza viene usata la CPU (più lenta).
   La selezione del device è gestita da `resolve_device` e può essere
   personalizzata impostando `compute.device` in `settings.yaml` o la
@@ -135,6 +136,12 @@ Per avviare con dispositivi audio diversi:
 audio:
   input_device: 2   # indice input (da sounddevice.query_devices)
   output_device: 5
+openai:
+  tts_voice: alloy   # voce TTS locale (pyttsx3)
+
+recording:
+  use_webrtcvad: true
+  vad_sensitivity: 2  # 0=più sensibile, 3=più severo
 ```
 
 Il file include inoltre sezioni per l'attivazione tramite **hotword** e per

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,5 @@ isort>=5.10.1
 mypy>=1.0.0
 ruff>=0.1.0
 faster-whisper>=1.0.0
+pyttsx3>=2.90
+webrtcvad>=2.0.10


### PR DESCRIPTION
## Summary
- integrate pyttsx3-based TTS in response pipeline
- switch to WebRTC-based VAD with configurable sensitivity
- expose voice and VAD settings in configuration and documentation
- document new audio dependencies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad074357dc8327bb5844c48519ab0e