### PR TITLE
feat: summarize chat history for llm context

### DIFF
--- a/OcchioOnniveggente/src/chat.py
+++ b/OcchioOnniveggente/src/chat.py
@@ -91,6 +91,14 @@ class ChatState:
     def push_assistant(self, text: str) -> None:
         self.push_message("assistant", text)
 
+    def summarize_history(self) -> None:
+        """Summarize the current conversation into ``summary`` and clear history."""
+
+        if not self.history:
+            return
+        self.summary = summarize_history(self.summary, self.history)
+        self.history.clear()
+
     def stream_assistant(self, tokens: "Iterator[str]") -> str:
         """Consume ``tokens`` updating the last assistant message incrementally.
 
@@ -180,6 +188,15 @@ class ChatState:
             else:
                 lines.append(f"{role}: {content}")
         path.write_text("\n".join(lines), encoding="utf-8")
+
+    def messages_for_llm(self) -> List[Dict[str, str]]:
+        """Return the history preceded by the cumulative summary if present."""
+
+        msgs: List[Dict[str, str]] = []
+        if self.summary:
+            msgs.append({"role": "system", "content": self.summary})
+        msgs.extend(self.history)
+        return msgs
 
     # ----------------- topic tracking -----------------
     def update_topic(

--- a/OcchioOnniveggente/src/conversation.py
+++ b/OcchioOnniveggente/src/conversation.py
@@ -69,5 +69,15 @@ class ConversationManager:
     def push_assistant(self, text: str) -> None:
         self.chat.push_assistant(text)
 
+    def summarize_history(self) -> None:
+        """Summarize and compact the managed chat history."""
+
+        self.chat.summarize_history()
+
+    def messages_for_llm(self) -> list[dict[str, str]]:
+        """Return recent messages including any accumulated summary."""
+
+        return self.chat.messages_for_llm()
+
 
 __all__ = ["ConversationManager", "DialogState"]

--- a/OcchioOnniveggente/src/main.py
+++ b/OcchioOnniveggente/src/main.py
@@ -482,7 +482,7 @@ def main() -> None:
                     if changed:
                         say("🔀 Cambio tema.")
                     pending_topic = chat.topic_text
-                    pending_history = chat.history
+                    pending_history = chat.messages_for_llm()
                 else:
                     pending_topic = None
                     pending_history = None

--- a/tests/test_conversation_history.py
+++ b/tests/test_conversation_history.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from OcchioOnniveggente.src.conversation import ConversationManager
+from OcchioOnniveggente.src.oracle import oracle_answer
+
+
+class DummyResp:
+    def __init__(self, text: str):
+        self.output_text = text
+
+
+class DummyResponses:
+    def __init__(self):
+        self.called_with = None
+
+    def create(self, *, model, instructions, input):
+        self.called_with = (model, instructions, input)
+        return DummyResp("ok")
+
+
+class DummyClient:
+    def __init__(self):
+        self.responses = DummyResponses()
+
+
+def test_history_summary_is_passed_to_model():
+    conv = ConversationManager()
+    chat = conv.chat
+    chat.max_turns = 1
+    conv.push_user("ciao")
+    conv.push_assistant("salve")
+    conv.push_user("come va?")
+    history = conv.messages_for_llm()
+    assert history[0]["role"] == "system"  # summary present
+    client = DummyClient()
+    oracle_answer(
+        question="prossima?",
+        lang_hint="it",
+        client=client,
+        llm_model="m",
+        style_prompt="",
+        history=history,
+    )
+    _, _, messages = client.responses.called_with
+    assert messages[0]["role"] == "system"
+    assert messages[-1]["content"] == "prossima?"


### PR DESCRIPTION
## Summary
- extend chat state with history summarization and helper to build LLM prompt
- expose summarization utilities via `ConversationManager`
- include condensed history in model requests and add regression test

## Testing
- `pytest tests/test_chat_memory.py tests/test_oracle_answer.py tests/test_conversation_history.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad0743e78083278998dc89257fa5ec