### PR TITLE
Add console logging to UI entry point

### DIFF
--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -2765,6 +2765,18 @@ UILogHandler = OracoloUI.UILogHandler
 
 # ----------------------------- entry point -------------------------------- #
 def main() -> None:
+    """Avvia l'interfaccia grafica e configura il logging di base."""
+
+    # In assenza di configurazione, l'aggiunta del gestore UILogHandler
+    # sopprime l'handler di fallback della libreria ``logging`` e niente viene
+    # mostrato in console.  Qui impostiamo esplicitamente un ``StreamHandler``
+    # in modo che i messaggi vengano stampati anche nel terminale mentre la
+    # finestra grafica resta responsabile di mostrarli nella viewport dei log.
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
     state = UIState()
     controller = UIController(state)
     app = OracoloUI(state=state, controller=controller)


### PR DESCRIPTION
## Summary
- Configure Python logging in `ui.py` so messages also reach the terminal when running the UI

## Testing
- `pytest` *(fails: SyntaxError in OcchioOnniveggente/src/oracle.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0d073e708327ad01d4d87cd5e676