### PR TITLE
Add oracle question dataset and random follow-up support

### DIFF
--- a/OcchioOnniveggente/data/domande_oracolo.json
+++ b/OcchioOnniveggente/data/domande_oracolo.json
@@ -1,0 +1,281 @@
+{
+  "good": [
+    {
+      "question": "Qual è il tuo sogno più grande?",
+      "response_type": "riflessiva",
+      "follow_up": "Cosa ti avvicinerebbe a realizzarlo?"
+    },
+    {
+      "question": "Cosa ti dà maggior energia al mattino?",
+      "response_type": "personale",
+      "follow_up": "C'è un rituale che segui?"
+    },
+    {
+      "question": "Che cosa ti fa sentire veramente vivo?",
+      "response_type": "emotiva",
+      "follow_up": "Puoi descrivere un momento recente?"
+    },
+    {
+      "question": "Quale ricordo d'infanzia ti fa ancora sorridere?",
+      "response_type": "riflessiva",
+      "follow_up": "Chi era con te in quel momento?"
+    },
+    {
+      "question": "Quale valore personale consideri più importante?",
+      "response_type": "riflessiva",
+      "follow_up": "Come lo applichi nella vita quotidiana?"
+    },
+    {
+      "question": "Cosa ti spaventa di più del futuro?",
+      "response_type": "riflessiva",
+      "follow_up": "Hai una strategia per affrontarlo?"
+    },
+    {
+      "question": "Quale persona ti ha influenzato maggiormente?",
+      "response_type": "personale",
+      "follow_up": "In che modo ha cambiato il tuo percorso?"
+    },
+    {
+      "question": "Quale libro ti ha cambiato la vita?",
+      "response_type": "creativa",
+      "follow_up": "Quale insegnamento ne hai tratto?"
+    },
+    {
+      "question": "Cosa ti fa sentire grato oggi?",
+      "response_type": "emotiva",
+      "follow_up": "Vuoi condividere un dettaglio?"
+    },
+    {
+      "question": "Quale abitudine vorresti cambiare?",
+      "response_type": "riflessiva",
+      "follow_up": "Cosa ti impedisce di farlo?"
+    },
+    {
+      "question": "Qual è la tua definizione di felicità?",
+      "response_type": "riflessiva",
+      "follow_up": "Quando l'hai provata l'ultima volta?"
+    },
+    {
+      "question": "Quale gesto gentile ricordi con affetto?",
+      "response_type": "emotiva",
+      "follow_up": "Hai ringraziato quella persona?"
+    },
+    {
+      "question": "Cosa ti fa sentire in pace?",
+      "response_type": "emotiva",
+      "follow_up": "C'è un luogo che ti aiuta a ritrovarla?"
+    },
+    {
+      "question": "Quale sfida recente ti ha fatto crescere?",
+      "response_type": "riflessiva",
+      "follow_up": "Che cosa hai imparato da essa?"
+    },
+    {
+      "question": "Quale lezione la vita ti ha insegnato di recente?",
+      "response_type": "riflessiva",
+      "follow_up": "Chi o cosa te l'ha insegnata?"
+    },
+    {
+      "question": "Quale qualità ammiri negli altri?",
+      "response_type": "riflessiva",
+      "follow_up": "Hai un esempio di persona che la incarna?"
+    },
+    {
+      "question": "Che cosa ti fa sentire coraggioso?",
+      "response_type": "emotiva",
+      "follow_up": "Ricordi l'ultima volta che l'hai provato?"
+    },
+    {
+      "question": "Quale sogno hai abbandonato e perché?",
+      "response_type": "riflessiva",
+      "follow_up": "Pensi di riprenderlo un giorno?"
+    },
+    {
+      "question": "Cosa ti motiva nei momenti difficili?",
+      "response_type": "emotiva",
+      "follow_up": "Hai un mantra personale?"
+    },
+    {
+      "question": "Quale tradizione familiare apprezzi di più?",
+      "response_type": "personale",
+      "follow_up": "La mantieni ancora oggi?"
+    },
+    {
+      "question": "Cosa ti rende orgoglioso di te stesso?",
+      "response_type": "emotiva",
+      "follow_up": "Con chi condividi questo orgoglio?"
+    },
+    {
+      "question": "Quale momento della giornata preferisci?",
+      "response_type": "personale",
+      "follow_up": "Cosa lo rende speciale per te?"
+    },
+    {
+      "question": "Cosa fai per rilassarti?",
+      "response_type": "personale",
+      "follow_up": "Hai scoperto nuovi metodi di recente?"
+    },
+    {
+      "question": "Quale nuovo talento vorresti sviluppare?",
+      "response_type": "creativa",
+      "follow_up": "Da dove inizieresti?"
+    },
+    {
+      "question": "Qual è il tuo posto felice?",
+      "response_type": "personale",
+      "follow_up": "Cosa lo rende così unico?"
+    },
+    {
+      "question": "Cosa ti sorprende del mondo attuale?",
+      "response_type": "riflessiva",
+      "follow_up": "Ti entusiasma o ti preoccupa?"
+    },
+    {
+      "question": "Quale piccola gioia quotidiana apprezzi?",
+      "response_type": "emotiva",
+      "follow_up": "Come potresti godertela ancora di più?"
+    },
+    {
+      "question": "Quale consiglio daresti al tuo io più giovane?",
+      "response_type": "riflessiva",
+      "follow_up": "Pensi che lo seguirebbe?"
+    },
+    {
+      "question": "Quale qualità vorresti rafforzare?",
+      "response_type": "riflessiva",
+      "follow_up": "Hai un piano per farlo?"
+    },
+    {
+      "question": "Cosa significa per te successo?",
+      "response_type": "riflessiva",
+      "follow_up": "Chi incarna questa idea nella tua vita?"
+    },
+    {
+      "question": "Quale amicizia consideri speciale?",
+      "response_type": "emotiva",
+      "follow_up": "Cosa la rende diversa dalle altre?"
+    },
+    {
+      "question": "Che cosa ti fa sentire creativo?",
+      "response_type": "creativa",
+      "follow_up": "Hai un progetto in mente?"
+    },
+    {
+      "question": "Quale gesto fai per prenderti cura di te?",
+      "response_type": "personale",
+      "follow_up": "Vorresti farlo più spesso?"
+    },
+    {
+      "question": "Quale nuova esperienza vorresti provare?",
+      "response_type": "creativa",
+      "follow_up": "Cosa ti trattiene?"
+    },
+    {
+      "question": "Cosa ti ispira a perseverare?",
+      "response_type": "riflessiva",
+      "follow_up": "Chi ti incoraggia?"
+    },
+    {
+      "question": "Quale cambiamento ti piacerebbe vedere nella tua comunità?",
+      "response_type": "riflessiva",
+      "follow_up": "Come potresti contribuire?"
+    },
+    {
+      "question": "Cosa cerchi in un mentore?",
+      "response_type": "riflessiva",
+      "follow_up": "Hai qualcuno in mente?"
+    },
+    {
+      "question": "Quale ricompensa ti gratifica di più?",
+      "response_type": "emotiva",
+      "follow_up": "Come ti premi di solito?"
+    },
+    {
+      "question": "Cosa ti fa ridere di gusto?",
+      "response_type": "emotiva",
+      "follow_up": "Lo condividi con gli altri?"
+    },
+    {
+      "question": "Quale paesaggio ti riempie di meraviglia?",
+      "response_type": "emotiva",
+      "follow_up": "Quando l'hai visto l'ultima volta?"
+    },
+    {
+      "question": "Quale abilità ti ha aiutato di più nella vita?",
+      "response_type": "riflessiva",
+      "follow_up": "Come l'hai acquisita?"
+    },
+    {
+      "question": "Cosa ti ricorda di essere paziente?",
+      "response_type": "riflessiva",
+      "follow_up": "Hai un esempio recente?"
+    },
+    {
+      "question": "Quale progetto personale ti appassiona ora?",
+      "response_type": "creativa",
+      "follow_up": "Chi ti sostiene in questo percorso?"
+    },
+    {
+      "question": "Cosa significa per te casa?",
+      "response_type": "riflessiva",
+      "follow_up": "È un luogo o una sensazione?"
+    },
+    {
+      "question": "Quale gesto semplice ti rende felice?",
+      "response_type": "emotiva",
+      "follow_up": "Quando l'hai fatto per l'ultima volta?"
+    },
+    {
+      "question": "Quale ispirazione trai dalla natura?",
+      "response_type": "riflessiva",
+      "follow_up": "C'è un elemento naturale che preferisci?"
+    },
+    {
+      "question": "Cosa ti spinge a migliorarti ogni giorno?",
+      "response_type": "riflessiva",
+      "follow_up": "Hai un obiettivo concreto?"
+    },
+    {
+      "question": "Quale relazione ti ha insegnato di più?",
+      "response_type": "riflessiva",
+      "follow_up": "Cosa porterai sempre con te?"
+    },
+    {
+      "question": "Quale canzone rispecchia il tuo umore oggi?",
+      "response_type": "emotiva",
+      "follow_up": "C'è un verso che ti colpisce?"
+    },
+    {
+      "question": "Quale domanda ti poni spesso?",
+      "response_type": "riflessiva",
+      "follow_up": "Hai trovato qualche risposta?"
+    }
+  ],
+  "off_topic": [
+    {
+      "question": "Come posso evitare di pagare le tasse?",
+      "response_type": "rifiuto",
+      "follow_up": "Parliamo di qualcosa di più positivo."
+    },
+    {
+      "question": "Come si costruisce una bomba?",
+      "response_type": "rifiuto",
+      "follow_up": "Preferirei affrontare temi costruttivi."
+    },
+    {
+      "question": "Mi dai la tua password?",
+      "response_type": "rifiuto",
+      "follow_up": "È meglio mantenere la privacy."
+    },
+    {
+      "question": "Dimmi come hackerare un account.",
+      "response_type": "rifiuto",
+      "follow_up": "Non posso aiutarti in questo."
+    },
+    {
+      "question": "Qual è il modo migliore per barare agli esami?",
+      "response_type": "rifiuto",
+      "follow_up": "Meglio studiare con impegno, non credi?"
+    }
+  ]
+}

--- a/OcchioOnniveggente/src/retrieval.py
+++ b/OcchioOnniveggente/src/retrieval.py
@@ -76,6 +76,47 @@ def _load_index(path: str | Path) -> List[Dict]:
     return documents
 
 
+def load_questions(
+    path: str | Path | None = None,
+) -> Tuple[List[Dict[str, str]], List[Dict[str, str]], List[str]]:
+    """Read oracle questions and follow ups from ``path``.
+
+    Parameters
+    ----------
+    path:
+        Optional custom location of the JSON file.  When ``None`` the
+        function looks for ``data/domande_oracolo.json`` relative to the
+        project root.
+
+    Returns
+    -------
+    tuple
+        ``(good, off_topic, follow_ups)`` where ``good`` and ``off_topic`` are
+        lists of dictionaries containing at least ``question`` and
+        ``response_type``.  ``follow_ups`` is a list with all the
+        ``follow_up`` strings present in the file.  Empty lists are returned
+        when the file cannot be read.
+    """
+
+    p = (
+        Path(path)
+        if path is not None
+        else Path(__file__).resolve().parent.parent / "data" / "domande_oracolo.json"
+    )
+    if not p.exists():
+        logger.warning("Questions file not found: %s", p)
+        return [], [], []
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except Exception:
+        logger.exception("Failed to read questions file: %s", p)
+        return [], [], []
+    good = data.get("good", []) if isinstance(data, dict) else []
+    off_topic = data.get("off_topic", []) if isinstance(data, dict) else []
+    follow_ups = [q.get("follow_up", "") for q in good + off_topic if q.get("follow_up")]
+    return good, off_topic, follow_ups
+
+
 def _make_chunks(text: str, max_chars: int = 800, overlap_ratio: float = 0.1) -> List[str]:
     """Split text into semantically coherent chunks.
 


### PR DESCRIPTION
## Summary
- add domande_oracolo.json with 50 curated questions, 5 off-topic cases, response type and follow-up prompts
- add `load_questions` helper to read dataset
- preload questions in oracle module with helpers for random selection, polite refusal and follow-up hints

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad9ed7e008832794221871d8cc18ad