### PR TITLE
feat: add question prompts and off topic handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,15 @@ Variabili utili:
 - `ORACOLO_WS_URL` – URL del server (default `ws://localhost:8765`)
 - `--sr` – sample-rate, `--in-dev` e `--out-dev` per dispositivi audio.
 
+### Modalità vocale
+
+All'avvio il client carica le domande da `data/domande_oracolo.json`,
+separandole tra **buone** e **off_topic**. Quando una nuova sessione inizia,
+viene scelta una domanda buona casuale e letta tramite sintesi vocale locale.
+Dopo ogni risposta valida l'Oracolo propone una micro‑domanda di follow‑up.
+Se la trascrizione dell'utente corrisponde a una voce off-topic, il sistema
+risponde con un cortese rifiuto generato dall'Oracolo e non propone follow‑up.
+
 ---
 
 ## 5. Gestione documenti (RAG)


### PR DESCRIPTION
## Summary
- preload oracle questions on websocket startup and prompt user with a random one
- detect off-topic questions, speak a refusal and propose follow-ups with local TTS
- document voice mode behaviour and new question file

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ada23511208327bf9e5f8e0dbbb21e