### PR TITLE
Avoid repeating random questions until category exhausted

### DIFF
--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -27,6 +27,12 @@ from .retrieval import load_questions
 
 QUESTIONS_BY_TYPE = load_questions()
 
+# Track questions already asked for each category during the current session.
+# Keys are category names (lowercase) and values are the indexes of questions
+# that have been served.  Once all questions in a category have been used the
+# set is cleared to start a new cycle.
+_USED_QUESTIONS: dict[str, set[int]] = {}
+
 
 # Risposte predefinite per domande fuori tema
 OFF_TOPIC_RESPONSES: dict[str, str] = {
@@ -427,12 +433,26 @@ def stream_generate(
 
 
 def random_question(category: str) -> dict[str, str] | None:
-    """Return a random question object from the desired ``category``."""
+    """Return a random question from ``category`` without immediate repeats.
 
-    qs = QUESTIONS_BY_TYPE.get(category.lower())
+    Questions already returned are tracked per category.  Once all questions in
+    a category have been used the tracking set is cleared, allowing the cycle to
+    restart.
+    """
+
+    cat = category.lower()
+    qs = QUESTIONS_BY_TYPE.get(cat)
     if not qs:
         return None
-    return random.choice(qs)
+
+    used = _USED_QUESTIONS.setdefault(cat, set())
+    if len(used) == len(qs):
+        used.clear()
+
+    available = [i for i in range(len(qs)) if i not in used]
+    idx = random.choice(available)
+    used.add(idx)
+    return qs[idx]
 
 
 def answer_with_followup(

--- a/tests/test_random_question.py
+++ b/tests/test_random_question.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from OcchioOnniveggente.src.oracle import (
+    QUESTIONS_BY_TYPE,
+    random_question,
+    _USED_QUESTIONS,
+)
+
+
+def test_random_question_no_repeat_until_exhaustion():
+    category = "poetica"
+    # reset session tracking
+    _USED_QUESTIONS.clear()
+
+    total = len(QUESTIONS_BY_TYPE[category])
+    seen = set()
+    for _ in range(total):
+        q = random_question(category)
+        assert q["domanda"] not in seen
+        seen.add(q["domanda"])
+
+    assert len(seen) == total
+    assert len(_USED_QUESTIONS[category]) == total
+
+    # After exhausting all questions, the next call should reset the set
+    q = random_question(category)
+    assert q["domanda"] in seen
+    assert len(_USED_QUESTIONS[category]) == 1


### PR DESCRIPTION
## Summary
- track asked questions per category in-memory
- reset category list when depleted in `random_question`
- add regression test ensuring no repeat before exhaustion

## Testing
- `pytest tests/test_random_question.py tests/test_oracle_answer.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adc244ac7c8327ad41750b9997d584