### PR TITLE
Handle async transcription

### DIFF
--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -574,7 +574,13 @@ async def synthesize_async(*args, **kwargs):  # pragma: no cover - thin wrapper
 
 
 
-def transcribe(audio_path: Path, client: Any, model: str, *, lang_hint: str | None = None) -> str | None:
+async def transcribe(
+    audio_path: Path,
+    client: Any,
+    model: str,
+    *,
+    lang_hint: str | None = None,
+) -> str | None:
     """Effettua una trascrizione gestendo gli errori in modo centralizzato.
 
     Il client passato deve esporre un metodo ``transcribe`` compatibile con le
@@ -586,20 +592,36 @@ def transcribe(audio_path: Path, client: Any, model: str, *, lang_hint: str | No
 
     try:
         if hasattr(client, "transcribe"):
-            return client.transcribe(audio_path, model, lang_hint=lang_hint)
+            result = client.transcribe(audio_path, model, lang_hint=lang_hint)
+            if inspect.isawaitable(result):
+                result = await result
+            return result
 
         # Fallback per ``AsyncOpenAI`` che espone l'API moderna
         with audio_path.open("rb") as f:
             params: dict[str, Any] = {"model": model, "file": f}
             if lang_hint:
                 params["language"] = lang_hint
-            response = client.audio.transcriptions.create(**params)
+            create = client.audio.transcriptions.create
+            if inspect.iscoroutinefunction(create):
+                response = await create(**params)
+            else:
+                response = create(**params)
+            if inspect.isawaitable(response):
+                response = await response
         return getattr(response, "text", None)
     except Exception as exc:  # noqa: BLE001 - delegato a handle_error
         return handle_error(exc, context="transcribe")
 
 
-def fast_transcribe(audio_path: Path, client: Any, model: str, *, lang_hint: str | None = None) -> str | None:
+async def fast_transcribe(
+    audio_path: Path,
+    client: Any,
+    model: str,
+    *,
+    lang_hint: str | None = None,
+) -> str | None:
     """Wrapper around :func:`transcribe` returning only the transcription text."""
-    return transcribe(audio_path, client, model, lang_hint=lang_hint)
+
+    return await transcribe(audio_path, client, model, lang_hint=lang_hint)
 

--- a/tests/test_transcription_errors.py
+++ b/tests/test_transcription_errors.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from pathlib import Path
 
@@ -11,7 +12,7 @@ class NetworkClient:
 
 def test_transcribe_network_error(caplog):
     with caplog.at_level(logging.WARNING):
-        msg = transcribe(Path("a.wav"), NetworkClient(), "model")
+        msg = asyncio.run(transcribe(Path("a.wav"), NetworkClient(), "model"))
     assert "controlla la connessione" in msg.lower()
     assert any(r.levelno == logging.WARNING for r in caplog.records)
     assert "context: transcribe" in caplog.text
@@ -24,7 +25,7 @@ class APIClient:
 
 def test_transcribe_api_error(caplog):
     with caplog.at_level(logging.ERROR):
-        msg = transcribe(Path("a.wav"), APIClient(), "model")
+        msg = asyncio.run(transcribe(Path("a.wav"), APIClient(), "model"))
     assert "errore dell'api" in msg.lower()
     assert any(r.levelno == logging.ERROR for r in caplog.records)
     assert "context: transcribe" in caplog.text
@@ -37,7 +38,7 @@ class AudioClient:
 
 def test_transcribe_audio_error(caplog):
     with caplog.at_level(logging.ERROR):
-        msg = transcribe(Path("a.wav"), AudioClient(), "model")
+        msg = asyncio.run(transcribe(Path("a.wav"), AudioClient(), "model"))
     assert "errore audio" in msg.lower()
     assert any(r.levelno == logging.ERROR for r in caplog.records)
     assert "context: transcribe" in caplog.text


### PR DESCRIPTION
## Summary
- make `transcribe` and `fast_transcribe` async-aware, awaiting coroutine responses from OpenAI-style clients
- adapt main application to run new async transcription helpers via `asyncio.run`
- update transcription error tests to use `asyncio.run`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adc292cbc08327974b147462f23294