### PR TITLE
Refactor question loading to use dataclasses

### DIFF
--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -25,11 +25,11 @@ from .utils.error_handler import handle_error
 from .retrieval import Question, load_questions
 
 
-_QUESTIONS_CACHE: dict[str, List[dict[str, Any]]] | None = None
+_QUESTIONS_CACHE: dict[str, List[Question]] | None = None
 _QUESTIONS_MTIME: float | None = None
 
 
-def get_questions() -> dict[str, List[dict[str, Any]]]:
+def get_questions() -> dict[str, List[Question]]:
     """Return the questions dataset reloading it when the file changes."""
 
     global _QUESTIONS_CACHE, _QUESTIONS_MTIME
@@ -452,19 +452,7 @@ def stream_generate(
 
 
 def random_question(category: str) -> Question | None:
-    """Return a random question object from the desired ``category``."""
-
-
-    qs = get_questions().get(category.lower())
-
-def random_question(category: str) -> dict[str, str] | None:
-    """Return a random question from ``category`` without immediate repeats.
-
-    Questions already returned are tracked per category.  Once all questions in
-    a category have been used the tracking set is cleared, allowing the cycle to
-    restart.
-    """
-
+    """Return a random question from ``category`` without immediate repeats."""
 
     cat = category.lower()
     qs = QUESTIONS_BY_TYPE.get(cat)
@@ -498,7 +486,7 @@ def answer_with_followup(
 
 
 def answer_and_log_followup(
-    question_data: dict[str, str],
+    question_data: Question,
     client: Any,
     llm_model: str,
     log_path: Path,
@@ -519,7 +507,7 @@ def answer_and_log_followup(
         question_data, client, llm_model, lang_hint=lang_hint
     )
     append_log(
-        question_data.get("domanda", ""),
+        question_data.domanda,
         answer,
         log_path,
         session_id=session_id,

--- a/tests/test_oracle_answer.py
+++ b/tests/test_oracle_answer.py
@@ -5,6 +5,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from OcchioOnniveggente.src.oracle import answer_and_log_followup, oracle_answer
+from OcchioOnniveggente.src.retrieval import Question
 
 
 class DummyResp:
@@ -49,7 +50,7 @@ def test_oracle_answer_returns_response_and_context():
 
 def test_answer_and_log_followup(tmp_path: Path):
     client = DummyClient()
-    qdata = {"domanda": "Chi sei?", "follow_up": "Vuoi continuare?"}
+    qdata = Question(domanda="Chi sei?", type="poetica", follow_up="Vuoi continuare?")
     log = tmp_path / "log.jsonl"
     answer, follow_up = answer_and_log_followup(
         qdata, client, "test-model", log, session_id="sess-1"

--- a/tests/test_random_question.py
+++ b/tests/test_random_question.py
@@ -19,13 +19,13 @@ def test_random_question_no_repeat_until_exhaustion():
     seen = set()
     for _ in range(total):
         q = random_question(category)
-        assert q["domanda"] not in seen
-        seen.add(q["domanda"])
+        assert q.domanda not in seen
+        seen.add(q.domanda)
 
     assert len(seen) == total
     assert len(_USED_QUESTIONS[category]) == total
 
     # After exhausting all questions, the next call should reset the set
     q = random_question(category)
-    assert q["domanda"] in seen
+    assert q.domanda in seen
     assert len(_USED_QUESTIONS[category]) == 1


### PR DESCRIPTION
## Summary
- Define `Question` dataclass and load questions into typed objects
- Expose questions grouped by type and refactor consumers to use dataclasses
- Update tests for new question API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adcdb273f883278cb649aab264a67c