### PR TITLE
Avoid repeated random questions

### DIFF
--- a/tests/test_random_question.py
+++ b/tests/test_random_question.py
@@ -19,13 +19,23 @@ def test_random_question_no_repeat_until_exhaustion():
     seen = set()
     for _ in range(total):
         q = random_question(category)
-        assert q["domanda"] not in seen
-        seen.add(q["domanda"])
+        assert q.domanda not in seen
+        seen.add(q.domanda)
 
     assert len(seen) == total
     assert len(_USED_QUESTIONS[category]) == total
 
     # After exhausting all questions, the next call should reset the set
     q = random_question(category)
-    assert q["domanda"] in seen
+    assert q.domanda in seen
     assert len(_USED_QUESTIONS[category]) == 1
+
+    # Drawing the remaining questions again should not repeat within the
+    # new cycle.
+    seen_second_cycle = {q.domanda}
+    for _ in range(total - 1):
+        q = random_question(category)
+        assert q.domanda not in seen_second_cycle
+        seen_second_cycle.add(q.domanda)
+
+    assert len(_USED_QUESTIONS[category]) == total


### PR DESCRIPTION
## Summary
- Track question indices per category to avoid repeats during a session.
- Reset tracking once all questions in a category have been used.
- Extend tests to ensure random questions do not repeat until the category is exhausted.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adcdc7080483278a65ef56937df65a