### PR TITLE
Add validation test for domande_oracolo.json

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: pip install pytest
+      - name: Run tests
+        run: pytest tests/test_domande_oracolo_json.py -q

--- a/tests/test_domande_oracolo_json.py
+++ b/tests/test_domande_oracolo_json.py
@@ -1,0 +1,33 @@
+import json
+from collections import Counter
+from pathlib import Path
+
+
+def test_domande_oracolo_structure_and_counts():
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "OcchioOnniveggente"
+        / "data"
+        / "domande_oracolo.json"
+    )
+    with path.open(encoding="utf-8") as f:
+        data = json.load(f)
+
+    assert isinstance(data, list)
+
+    counts = Counter()
+    for entry in data:
+        assert "domanda" in entry
+        assert "type" in entry
+        assert isinstance(entry["domanda"], str)
+        assert isinstance(entry["type"], str)
+        if "follow_up" in entry:
+            assert isinstance(entry["follow_up"], str)
+        counts[entry["type"]] += 1
+
+    assert counts == {
+        "poetica": 50,
+        "didattica": 50,
+        "evocativa": 50,
+        "orientamento": 50,
+    }


### PR DESCRIPTION
## Summary
- add pytest checking domande_oracolo.json structure and category counts
- set up GitHub Actions workflow running the new test

## Testing
- `pytest tests/test_domande_oracolo_json.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68adcdd5b8748327a1e55a516c33d054