### PR TITLE
feat: support context-aware question selection

### DIFF
--- a/tests/test_random_question.py
+++ b/tests/test_random_question.py
@@ -3,8 +3,9 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+from OcchioOnniveggente.src.retrieval import Context
 from OcchioOnniveggente.src.oracle import (
-    QUESTIONS_BY_TYPE,
+    QUESTIONS_BY_CONTEXT,
     random_question,
     _USED_QUESTIONS,
 )
@@ -12,20 +13,21 @@ from OcchioOnniveggente.src.oracle import (
 
 def test_random_question_no_repeat_until_exhaustion():
     category = "poetica"
+    context = Context.GENERIC
     # reset session tracking
     _USED_QUESTIONS.clear()
 
-    total = len(QUESTIONS_BY_TYPE[category])
+    total = len(QUESTIONS_BY_CONTEXT[context][category])
     seen = set()
     for _ in range(total):
-        q = random_question(category)
-        assert q["domanda"] not in seen
-        seen.add(q["domanda"])
+        q = random_question(category, context)
+        assert q.domanda not in seen
+        seen.add(q.domanda)
 
     assert len(seen) == total
-    assert len(_USED_QUESTIONS[category]) == total
+    assert len(_USED_QUESTIONS[(context, category)]) == total
 
     # After exhausting all questions, the next call should reset the set
-    q = random_question(category)
-    assert q["domanda"] in seen
-    assert len(_USED_QUESTIONS[category]) == 1
+    q = random_question(category, context)
+    assert q.domanda in seen
+    assert len(_USED_QUESTIONS[(context, category)]) == 1


### PR DESCRIPTION
## Summary
- add `Context` enum and enhance `load_questions` to handle multiple datasets
- expose context-aware cache and `random_question` selector
- update tests for new context functionality

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adcee0243083278e0469c941029e6f