### PR TITLE
Add optional metadata for question dataset

### DIFF
--- a/OcchioOnniveggente/README.md
+++ b/OcchioOnniveggente/README.md
@@ -71,20 +71,34 @@ numero, Pydantic segnalerà `Input should be a valid integer` e userà `24000`.
 
 Le domande che l'Oracolo può proporre sono raccolte nel file
 `data/domande_oracolo.json`.  Ogni elemento del file è una struttura con i
-campi `domanda`, `type` e un eventuale `follow_up`:
+campi `domanda`, `type` e un eventuale `follow_up`.  È inoltre possibile
+aggiungere metadati opzionali `opera`, `artista`, `location` e `tag`:
 
 ```json
 {
-  "domanda": "Quale metafora descrive il tuo percorso di vita?",
+  "domanda": "Quale messaggio ti trasmette l'opera CryptoMadonne?",
   "type": "poetica",
-  "follow_up": "Ti va di approfondire questa immagine?"
+  "follow_up": "In che modo ti ispira?",
+  "opera": "CryptoMadonne",
+  "artista": "Artista Sconosciuto",
+  "location": "museo",
+  "tag": ["CryptoMadonne"]
 }
 ```
 
 Le tipologie disponibili sono `poetica`, `didattica`, `evocativa` e
 `orientamento`.  La funzione `load_questions()` in `src/retrieval.py` carica il
 dataset restituendo un dizionario che mappa ogni categoria alla relativa lista
-di domande.
+di domande. I metadati sono accessibili come attributi dell'oggetto
+`Question` e possono essere usati per ricerche mirate. Esempio di filtro per
+tag:
+
+```python
+from OcchioOnniveggente.src.retrieval import load_questions
+
+qs = load_questions()
+crypto = [q.domanda for qq in qs.values() for q in qq if q.tag and "CryptoMadonne" in q.tag]
+```
 
 Nel modulo `src/oracle.py` è possibile ottenere una domanda casuale tramite
 `random_question("poetica")` e generare una risposta con

--- a/OcchioOnniveggente/data/domande_oracolo.json
+++ b/OcchioOnniveggente/data/domande_oracolo.json
@@ -1,4 +1,12 @@
-[
+[{
+    "domanda": "Quale messaggio ti trasmette l'opera CryptoMadonne?",
+    "type": "poetica",
+    "follow_up": "In che modo ti ispira?",
+    "opera": "CryptoMadonne",
+    "artista": "Artista Sconosciuto",
+    "location": "museo",
+    "tag": ["CryptoMadonne"]
+  },
   {
     "domanda": "Quale metafora descrive il tuo percorso di vita?",
     "type": "poetica",

--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -483,17 +483,20 @@ def random_question(category: str) -> dict[str, str] | None:
 
 
 def answer_with_followup(
-    question_data: Question,
+    question_data: Question | dict[str, Any],
     client: Any,
     llm_model: str,
     *,
     lang_hint: str = "it",
 ) -> tuple[str, str]:
     """Generate an answer for ``question_data`` and return its follow-up."""
-
-    question = question_data.domanda
+    if isinstance(question_data, dict):
+        question = question_data.get("domanda", "")
+        follow_up = question_data.get("follow_up") or ""
+    else:
+        question = question_data.domanda
+        follow_up = question_data.follow_up or ""
     answer, _ = oracle_answer(question, lang_hint, client, llm_model, "")
-    follow_up = question_data.follow_up or ""
     return answer, follow_up
 
 

--- a/OcchioOnniveggente/src/retrieval.py
+++ b/OcchioOnniveggente/src/retrieval.py
@@ -54,6 +54,13 @@ class Question:
     domanda: str
     type: str
     follow_up: str | None = None
+    opera: str | None = None
+    artista: str | None = None
+    location: str | None = None
+    tag: List[str] | None = None
+
+    def __getitem__(self, key: str) -> Any:
+        return getattr(self, key)
 
 
 def _simple_sentences(txt: str) -> List[str]:
@@ -162,9 +169,34 @@ def load_questions(path: str | Path | None = None) -> Dict[str, List[Question]]:
             follow_up = item.get("follow_up")
             if follow_up is not None and not isinstance(follow_up, str):
                 follow_up = str(follow_up)
+            opera = item.get("opera")
+            if opera is not None and not isinstance(opera, str):
+                opera = str(opera)
+            artista = item.get("artista")
+            if artista is not None and not isinstance(artista, str):
+                artista = str(artista)
+            location = item.get("location")
+            if location is not None and not isinstance(location, str):
+                location = str(location)
+            tag_field = item.get("tag")
+            tags: List[str] | None
+            if tag_field is None:
+                tags = None
+            elif isinstance(tag_field, list):
+                tags = [str(t) for t in tag_field if isinstance(t, (str, int, float))]
+            else:
+                tags = [str(tag_field)]
             cat = qtype.lower()
             categories.setdefault(cat, []).append(
-                Question(domanda=domanda, type=cat, follow_up=follow_up)
+                Question(
+                    domanda=domanda,
+                    type=cat,
+                    follow_up=follow_up,
+                    opera=opera,
+                    artista=artista,
+                    location=location,
+                    tag=tags,
+                )
             )
 
     return categories

--- a/tests/test_question_metadata.py
+++ b/tests/test_question_metadata.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from OcchioOnniveggente.src.retrieval import load_questions
+
+
+def test_question_metadata_fields():
+    qs = load_questions()
+    tagged = [q for qq in qs.values() for q in qq if q.tag and "CryptoMadonne" in q.tag]
+    assert tagged, "No question tagged CryptoMadonne"
+    q = tagged[0]
+    assert q.opera == "CryptoMadonne"
+    assert q["opera"] == "CryptoMadonne"
+


### PR DESCRIPTION
## Summary
- extend `Question` model with optional metadata fields and dictionary-like access
- parse and validate new metadata in `load_questions`
- document question metadata usage and filtering in README
- add example question with `CryptoMadonne` tag and test coverage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adcee417c083278b9558228f4096c6