### PR TITLE
feat: add question session

### DIFF
--- a/OcchioOnniveggente/src/question_session.py
+++ b/OcchioOnniveggente/src/question_session.py
@@ -1,0 +1,49 @@
+"""Utilities for serving non-repeating questions within a session."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+import random
+
+from .retrieval import Question
+
+
+@dataclass
+class QuestionSession:
+    """Maintain per-category question rotation state.
+
+    Parameters
+    ----------
+    questions:
+        Mapping from category name to the list of :class:`Question` objects
+        belonging to that category. Category keys are treated case-insensitively.
+    """
+
+    questions: Dict[str, List[Question]]
+    _asked_ids: Dict[str, set[int]] = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        # Normalise categories to lowercase and initialise tracking sets
+        self.questions = {cat.lower(): list(qs) for cat, qs in self.questions.items()}
+        self._asked_ids = {cat: set() for cat in self.questions}
+
+    def next_question(self, category: str) -> Question | None:
+        """Return a question from ``category`` avoiding immediate repeats.
+
+        Once all questions in the category have been served the internal pool is
+        reset so that a new cycle can begin.
+        """
+
+        cat = category.lower()
+        qs = self.questions.get(cat)
+        if not qs:
+            return None
+
+        asked = self._asked_ids.setdefault(cat, set())
+        remaining = [i for i in range(len(qs)) if i not in asked]
+        if not remaining:
+            asked.clear()
+            remaining = list(range(len(qs)))
+        idx = random.choice(remaining)
+        asked.add(idx)
+        return qs[idx]

--- a/tests/test_question_session.py
+++ b/tests/test_question_session.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from OcchioOnniveggente.src.question_session import QuestionSession
+from OcchioOnniveggente.src.retrieval import Question
+
+
+def test_session_serves_all_questions_before_repeat():
+    questions = {
+        "demo": [
+            Question(domanda="q1", type="demo"),
+            Question(domanda="q2", type="demo"),
+            Question(domanda="q3", type="demo"),
+        ]
+    }
+    session = QuestionSession(questions)
+    seen = set()
+    total = len(questions["demo"])
+    for _ in range(total):
+        q = session.next_question("demo")
+        assert q.domanda not in seen
+        seen.add(q.domanda)
+    assert len(seen) == total
+
+    # Next question should come from new cycle
+    q = session.next_question("demo")
+    assert q.domanda in seen


### PR DESCRIPTION
## Summary
- implement `QuestionSession` to rotate question IDs per category without immediate repeats
- add tests for question rotation across cycles

## Testing
- `pytest tests/test_question_session.py -q`
- `pytest tests/test_random_question.py::test_random_question_no_repeat_until_exhaustion -q` *(fails: SyntaxError: invalid syntax)*

------
https://chatgpt.com/codex/tasks/task_e_68add2f88ab0832793865776298a7950