### PR TITLE
feat: persist question session state

### DIFF
--- a/OcchioOnniveggente/src/question_session.py
+++ b/OcchioOnniveggente/src/question_session.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 """Session helper combining question rotation and answer tracking."""
 
 from dataclasses import dataclass, field
+import atexit
+import json
+import os
+import pickle
 import random
 from typing import Dict, List, Optional
 
@@ -20,6 +24,7 @@ class QuestionSession:
     weights: Optional[Dict[str, float]] = None
     answers: List[str] = field(default_factory=list)
     replies: List[str] = field(default_factory=list)
+    state_path: str | os.PathLike[str] | None = None
 
     def __post_init__(self) -> None:
         if self.questions is None:
@@ -29,6 +34,11 @@ class QuestionSession:
         self._categories = list(self.questions.keys())
         self._index = 0
         self._used: Dict[str, set[int]] = {cat: set() for cat in self._categories}
+        if self.state_path:
+            path = os.fspath(self.state_path)
+            if os.path.exists(path):
+                self.load(path)
+            atexit.register(self.save, path)
 
     def next_question(self, category: str | None = None) -> Question | None:
         """Return a question, cycling categories and avoiding repeats."""
@@ -62,3 +72,35 @@ class QuestionSession:
         self.answers.append(answer)
         if reply is not None:
             self.replies.append(reply)
+
+    def save(self, path: str | os.PathLike[str]) -> None:
+        """Persist session state to ``path`` in JSON or pickle format."""
+
+        path = os.fspath(path)
+        data = {
+            "used": {k: list(v) for k, v in self._used.items()},
+            "answers": self.answers,
+            "replies": self.replies,
+            "index": self._index,
+        }
+        if path.endswith(".json"):
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(data, f)
+        else:
+            with open(path, "wb") as f:
+                pickle.dump(data, f)
+
+    def load(self, path: str | os.PathLike[str]) -> None:
+        """Load session state from ``path``."""
+
+        path = os.fspath(path)
+        if path.endswith(".json"):
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        else:
+            with open(path, "rb") as f:
+                data = pickle.load(f)
+        self._used = {k: set(v) for k, v in data.get("used", {}).items()}
+        self.answers = data.get("answers", [])
+        self.replies = data.get("replies", [])
+        self._index = data.get("index", 0)

--- a/tests/test_question_session_persistence.py
+++ b/tests/test_question_session_persistence.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from OcchioOnniveggente.src.retrieval import Question
+from OcchioOnniveggente.src.question_session import QuestionSession
+
+
+def test_rotation_after_reload(tmp_path: Path) -> None:
+    questions = {
+        "a": [Question(domanda="qa", type="a")],
+        "b": [Question(domanda="qb", type="b")],
+    }
+    state = tmp_path / "session.json"
+
+    session = QuestionSession(questions, state_path=state)
+    first = session.next_question()
+    assert first.type == "a"
+    session.record_answer("ans", "rep")
+    session.save(state)
+
+    restored = QuestionSession(questions, state_path=state)
+    assert restored.answers == ["ans"]
+    assert restored.replies == ["rep"]
+
+    second = restored.next_question()
+    assert second.type == "b"
+    third = restored.next_question()
+    assert third.type == "a"


### PR DESCRIPTION
## Summary
- add save/load methods to persist question session state
- reload state automatically when a path is provided
- cover persistence with rotation test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ade4c336e8832781a659b74f46cdb5