### PR TITLE
chore: consolidate QuestionSession implementation

### DIFF
--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -481,38 +481,8 @@ class ConversationFlow:
         return self.index >= len(self.flow) - 1
 
 
-@dataclass
-class QuestionSession:
-    """Serve questions cycling through categories.
-
-    When ``weights`` is provided, categories with a weight of ``0`` are ignored
-    and the remaining ones are sampled according to the specified weights.  When
-    weights are not supplied, categories are served in round-robin order.
-    """
-
-    weights: Dict[str, float] | None = None
-
-    def __post_init__(self) -> None:
-        self._categories = list(get_questions().keys())
-        self._index = 0
-
-    def next_question(self) -> Question:
-        if self.weights:
-            cats = [c for c in self._categories if self.weights.get(c, 0) > 0]
-            weights = [self.weights.get(c, 0) for c in cats]
-            if not cats:
-                return Question(domanda="", type="")
-            cat = random.choices(cats, weights=weights, k=1)[0]
-        else:
-            cat = self._categories[self._index]
-            self._index = (self._index + 1) % len(self._categories)
-        q = random_question(cat)
-        return q if q is not None else Question(domanda="", type=cat)
-
-
 __all__ = [
     "ConversationFlow",
-    "QuestionSession",
     "DEFAULT_FOLLOW_UPS",
     "OFF_TOPIC_RESPONSES",
     "OFF_TOPIC_REPLIES",

--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ cortese rifiuto adeguata al contesto.
 
 ## Sequenza delle categorie di domande
 
-Il modulo `oracle` offre la classe `QuestionSession` per gestire la scelta delle
-categorie quando non ne viene specificata una esplicitamente.  Di default le
-categorie vengono proposte in rotazione **round‑robin**, evitando ripetizioni
-immediate.  È possibile modificare le probabilità di estrazione definendo delle
-"pesature" in `settings.yaml` oppure passando un dizionario `weights` al
-costruttore:
+Il modulo `question_session` offre la classe `QuestionSession` per gestire la
+scelta delle categorie quando non ne viene specificata una esplicitamente e per
+memorizzare le risposte fornite dall'utente.  Di default le categorie vengono
+proposte in rotazione **round‑robin**, evitando ripetizioni immediate.  È
+possibile modificare le probabilità di estrazione definendo delle "pesature" in
+`settings.yaml` oppure passando un dizionario `weights` al costruttore:
 
 ```python
-from OcchioOnniveggente.src.oracle import QuestionSession
+from OcchioOnniveggente.src.question_session import QuestionSession
 
 session = QuestionSession(weights={"poetica": 0.7, "didattica": 0.2, "orientamento": 0.1})
 next_q = session.next_question()  # sceglie la categoria in base alle pesature
@@ -47,6 +47,14 @@ question_weights:
 
 Quando le pesature non sono specificate, `QuestionSession` ruota le categorie
 in ordine deterministico.
+
+Le risposte e gli eventuali commenti dell'utente possono essere registrati
+tramite `record_answer`:
+
+```python
+session.record_answer("risposta del sistema", reply="grazie")
+print(session.answers, session.replies)
+```
 
 ## Aggiornamenti backend
 

--- a/tests/test_question_session.py
+++ b/tests/test_question_session.py
@@ -4,7 +4,8 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 
-from OcchioOnniveggente.src.oracle import QuestionSession, get_questions
+from OcchioOnniveggente.src.question_session import QuestionSession
+from OcchioOnniveggente.src.oracle import get_questions
 
 
 def test_round_robin_rotation():
@@ -24,7 +25,6 @@ def test_weighted_selection():
     chosen = {session.next_question().type for _ in range(10)}
     assert chosen == {target}
 
-from OcchioOnniveggente.src.question_session import QuestionSession
 from OcchioOnniveggente.src.retrieval import Question
 
 


### PR DESCRIPTION
## Summary
- drop QuestionSession definition from `oracle` and keep single implementation in `question_session`
- update imports and tests to use the new module
- expand README with consolidated API documentation

## Testing
- `pytest tests/test_question_session.py tests/test_question_session_cycle.py`


------
https://chatgpt.com/codex/tasks/task_e_68ade58d44448327998f0a7b8899b403