### PR TITLE
Add RNG option to QuestionSession

### DIFF
--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -491,10 +491,12 @@ class QuestionSession:
     """
 
     weights: Dict[str, float] | None = None
+    rng: random.Random | None = None
 
     def __post_init__(self) -> None:
         self._categories = list(get_questions().keys())
         self._index = 0
+        self._rng = self.rng or random
 
     def next_question(self) -> Question:
         if self.weights:
@@ -502,7 +504,7 @@ class QuestionSession:
             weights = [self.weights.get(c, 0) for c in cats]
             if not cats:
                 return Question(domanda="", type="")
-            cat = random.choices(cats, weights=weights, k=1)[0]
+            cat = self._rng.choices(cats, weights=weights, k=1)[0]
         else:
             cat = self._categories[self._index]
             self._index = (self._index + 1) % len(self._categories)

--- a/OcchioOnniveggente/src/question_session.py
+++ b/OcchioOnniveggente/src/question_session.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import random
+from random import Random
 from typing import Dict, List, Optional
 
 from .oracle import get_questions
@@ -20,6 +21,7 @@ class QuestionSession:
     weights: Optional[Dict[str, float]] = None
     answers: List[str] = field(default_factory=list)
     replies: List[str] = field(default_factory=list)
+    rng: Random | None = None
 
     def __post_init__(self) -> None:
         if self.questions is None:
@@ -29,6 +31,7 @@ class QuestionSession:
         self._categories = list(self.questions.keys())
         self._index = 0
         self._used: Dict[str, set[int]] = {cat: set() for cat in self._categories}
+        self._rng = self.rng or random
 
     def next_question(self, category: str | None = None) -> Question | None:
         """Return a question, cycling categories and avoiding repeats."""
@@ -39,7 +42,7 @@ class QuestionSession:
                 weights = [self.weights.get(c, 0) for c in cats]
                 if not cats:
                     return None
-                category = random.choices(cats, weights=weights, k=1)[0]
+                category = self._rng.choices(cats, weights=weights, k=1)[0]
             else:
                 category = self._categories[self._index]
                 self._index = (self._index + 1) % len(self._categories)
@@ -52,7 +55,7 @@ class QuestionSession:
         if not remaining:
             used.clear()
             remaining = list(range(len(qs)))
-        idx = random.choice(remaining)
+        idx = self._rng.choice(remaining)
         used.add(idx)
         return qs[idx]
 

--- a/tests/test_question_session.py
+++ b/tests/test_question_session.py
@@ -1,14 +1,15 @@
 import sys
 from pathlib import Path
+import random
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 
-from OcchioOnniveggente.src.oracle import QuestionSession, get_questions
+from OcchioOnniveggente.src.oracle import QuestionSession as OracleQuestionSession, get_questions
 
 
 def test_round_robin_rotation():
-    session = QuestionSession()
+    session = OracleQuestionSession(rng=random.Random(0))
     categories = session._categories.copy()
     # consume one full cycle
     seen = [session.next_question().type for _ in range(len(categories))]
@@ -20,7 +21,7 @@ def test_round_robin_rotation():
 def test_weighted_selection():
     categories = list(get_questions().keys())
     target = categories[0]
-    session = QuestionSession(weights={target: 1.0})
+    session = OracleQuestionSession(weights={target: 1.0}, rng=random.Random(0))
     chosen = {session.next_question().type for _ in range(10)}
     assert chosen == {target}
 
@@ -36,7 +37,7 @@ def test_session_serves_all_questions_before_repeat():
             Question(domanda="q3", type="demo"),
         ]
     }
-    session = QuestionSession(questions)
+    session = QuestionSession(questions, rng=random.Random(0))
     seen = set()
     total = len(questions["demo"])
     for _ in range(total):


### PR DESCRIPTION
## Summary
- add optional RNG to QuestionSession and use it for question selection
- update tests to provide seeded Random instances

## Testing
- `pytest tests/test_question_session.py tests/test_question_session_cycle.py`

------
https://chatgpt.com/codex/tasks/task_e_68ade59a20488327bded1ae8dccc9065