### PR TITLE
Add tag-based question filtering to QuestionSession

### DIFF
--- a/OcchioOnniveggente/src/question_session.py
+++ b/OcchioOnniveggente/src/question_session.py
@@ -30,31 +30,55 @@ class QuestionSession:
         self._index = 0
         self._used: Dict[str, set[int]] = {cat: set() for cat in self._categories}
 
-    def next_question(self, category: str | None = None) -> Question | None:
-        """Return a question, cycling categories and avoiding repeats."""
+    def next_question(
+        self, category: str | None = None, tags: set[str] | None = None
+    ) -> Question | None:
+        """Return a question, cycling categories and avoiding repeats.
 
-        if category is None:
-            if self.weights:
-                cats = [c for c in self._categories if self.weights.get(c, 0) > 0]
-                weights = [self.weights.get(c, 0) for c in cats]
-                if not cats:
-                    return None
-                category = random.choices(cats, weights=weights, k=1)[0]
-            else:
-                category = self._categories[self._index]
-                self._index = (self._index + 1) % len(self._categories)
-        cat = category.lower()
-        qs = self.questions.get(cat, [])
-        if not qs:
-            return None
-        used = self._used.setdefault(cat, set())
-        remaining = [i for i in range(len(qs)) if i not in used]
-        if not remaining:
-            used.clear()
-            remaining = list(range(len(qs)))
-        idx = random.choice(remaining)
-        used.add(idx)
-        return qs[idx]
+        When ``tags`` is provided only questions containing *all* the
+        requested tags are considered.  If no question in the selected
+        category matches, another category is tried unless ``category`` was
+        explicitly supplied.
+        """
+
+        user_specified = category is not None
+        tried: set[str] = set()
+        for _ in range(len(self._categories)):
+            if category is None:
+                if self.weights:
+                    cats = [
+                        c
+                        for c in self._categories
+                        if self.weights.get(c, 0) > 0 and c not in tried
+                    ]
+                    weights = [self.weights.get(c, 0) for c in cats]
+                    if not cats:
+                        return None
+                    category = random.choices(cats, weights=weights, k=1)[0]
+                else:
+                    category = self._categories[self._index]
+                    self._index = (self._index + 1) % len(self._categories)
+                    if category in tried:
+                        category = None
+                        continue
+            cat = category.lower()
+            qs = self.questions.get(cat, [])
+            if tags:
+                qs = [q for q in qs if q.tag and tags <= set(q.tag)]
+            if qs:
+                used = self._used.setdefault(cat, set())
+                remaining = [i for i in range(len(qs)) if i not in used]
+                if not remaining:
+                    used.clear()
+                    remaining = list(range(len(qs)))
+                idx = random.choice(remaining)
+                used.add(idx)
+                return qs[idx]
+            if user_specified:
+                return None
+            tried.add(category)
+            category = None
+        return None
 
     def record_answer(self, answer: str, reply: str | None = None) -> None:
         """Store ``answer`` and optional user ``reply``."""

--- a/tests/test_question_session.py
+++ b/tests/test_question_session.py
@@ -49,3 +49,30 @@ def test_session_serves_all_questions_before_repeat():
     q = session.next_question("demo")
     assert q.domanda in seen
 
+
+def test_next_question_filters_by_tags():
+    questions = {
+        "demo": [
+            Question(domanda="q1", type="demo", tag=["a", "b"]),
+            Question(domanda="q2", type="demo", tag=["b"]),
+        ]
+    }
+    session = QuestionSession(questions)
+    q = session.next_question("demo", tags={"a"})
+    assert q.domanda == "q1"
+    assert session.next_question("demo", tags={"z"}) is None
+
+
+def test_next_question_recalculates_category_for_tags():
+    questions = {
+        "a": [Question(domanda="qa", type="a", tag=["x"])],
+        "b": [Question(domanda="qb", type="b", tag=["y"])],
+    }
+    session = QuestionSession(questions)
+    q = session.next_question(tags={"y"})
+    assert q.type == "b"
+    assert "y" in (q.tag or [])
+
+    # No category contains requested tag
+    assert session.next_question(tags={"not-there"}) is None
+


### PR DESCRIPTION
## Summary
- extend `QuestionSession.next_question` with optional `tags` filter
- skip categories without matching tagged questions, retrying when needed
- add unit tests for tag filtering and category recalculation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ade5cf9a808327bdfc4fd537f8c001