### PR TITLE
Inline tone in style prompt for oracle call

### DIFF
--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -1093,13 +1093,16 @@ class OracoloUI(tk.Tk):
             pin_ctx = [{"id": f"pin{i}", "text": t} for i, t in enumerate(self.chat_state.pinned)]
             ctx = pin_ctx + ctx
             tone = self.settings.get("tone", "informal")
+            if tone:
+                style_prompt = (
+                    f"{style_prompt}\nTone: {tone}" if style_prompt else f"Tone: {tone}"
+                )
             ans, used_ctx = await oracle_answer_async(
                 text,
                 lang,
                 client,
                 self.settings.get("llm_model", "gpt-4o"),
                 style_prompt,
-                tone=tone,
                 context=ctx,
                 history=self.chat_state.history,
                 topic=self.chat_state.topic_text,


### PR DESCRIPTION
## Summary
- Merge `tone` setting into `style_prompt` to simplify oracle call
- Remove unsupported `tone` keyword from `oracle_answer_async` usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aded8781b48327b22e4f8e06775e77