### PR TITLE
Initialize stdout text fallback before parsing

### DIFF
--- a/OcchioOnniveggente/src/ui.py
+++ b/OcchioOnniveggente/src/ui.py
@@ -2492,6 +2492,7 @@ class OracoloUI(tk.Tk):
                 time.sleep(0.05)
                 continue
             raw = line.rstrip("\n")
+            text = raw
             try:
                 data = json.loads(raw)
                 typ = data.get("type")
@@ -2509,7 +2510,7 @@ class OracoloUI(tk.Tk):
             except Exception:
                 self.after(
                     0,
-                    lambda t=raw: self._append_log(
+                    lambda t=text: self._append_log(
                         t + ("\n" if not t.endswith("\n") else ""), "LLM"
                     ),
                 )


### PR DESCRIPTION
## Summary
- ensure `_read_stdout` keeps a valid `text` string even when JSON parsing fails
- use pre-parsed text for logging fallback so prefix checks work reliably

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adfab33a9c83279a9dab23f5108f23