### PR TITLE
Unify QML chat history and logging view

### DIFF
--- a/OcchioOnniveggente/src/qml/MainSciFi.qml
+++ b/OcchioOnniveggente/src/qml/MainSciFi.qml
@@ -63,18 +63,6 @@ Window {
                             width: 260
                             height: 60
                         }
-                        NeonIconButton {
-                            anchors.horizontalCenter: parent.horizontalCenter
-                            iconText: "\uD83C\uDFA4" // microphone emoji
-                            onClicked: Bridge.onMicTapped()
-                        }
-                        Text {
-                            anchors.horizontalCenter: parent.horizontalCenter
-                            text: "WAKE WORD RECOGNIZED"
-                            font.family: Theme.font
-                            font.pixelSize: 12
-                            color: Bridge.wakeWordRecognized ? Theme.neonA : Theme.textSoft
-                        }
                     }
                 }
 
@@ -84,35 +72,29 @@ Window {
                     anchors.bottom: parent.bottom
                     width: parent.width * 0.55
 
-                    Column {
+                    Item {
                         anchors.fill: parent
                         anchors.margins: 16
-                        spacing: 12
 
-                        Flickable {
+                        ChatHistory {
                             id: chatView
                             anchors.left: parent.left
                             anchors.right: parent.right
                             anchors.top: parent.top
                             anchors.bottom: inputRow.top
-                            contentWidth: width
-                            clip: true
-                            Column {
-                                id: chatColumn
-                                width: chatView.width
-                                spacing: 10
-                                ChatBubble { text: "Quali sono gli orari di apertura?"; fromUser: true }
-                                ChatBubble { text: "Certamente. Gli orari di apertura del museo sono dal martedì alla domenica, dalle 9:00 alle 19:00, il lunedì siamo chiusi."; fromUser: false }
-                            }
+                            historyModel: Bridge.historyModel
                         }
 
                         Row {
                             id: inputRow
-                            width: parent.width
+                            anchors.left: parent.left
+                            anchors.right: parent.right
+                            anchors.bottom: logArea.top
                             spacing: 8
                             TextField {
                                 id: inputField
-                                width: parent.width - sendButton.width - 8
+                                anchors.verticalCenter: parent.verticalCenter
+                                width: parent.width - sendButton.width - micButton.width - 16
                                 color: Theme.text
                                 placeholderText: "Scrivi..."
                                 placeholderTextColor: Theme.textSoft
@@ -125,11 +107,37 @@ Window {
                                 }
                             }
                             NeonIconButton {
+                                id: micButton
+                                width: 56
+                                height: 56
+                                iconText: "\uD83C\uDFA4"
+                                onClicked: Bridge.onMicTapped()
+                            }
+                            NeonIconButton {
                                 id: sendButton
                                 width: 56
                                 height: 56
                                 iconText: "\u27A4"
-                                onClicked: Bridge.onSendPressed()
+                                onClicked: { Bridge.sendText(inputField.text); inputField.text = "" }
+                            }
+                        }
+
+                        TextArea {
+                            id: logArea
+                            anchors.left: parent.left
+                            anchors.right: parent.right
+                            anchors.bottom: parent.bottom
+                            height: 120
+                            readOnly: true
+                            wrapMode: TextArea.Wrap
+                            text: Bridge.logText
+                            color: Theme.text
+                            font.family: Theme.font
+                            background: Rectangle {
+                                color: Theme.panel
+                                radius: Theme.radius
+                                border.color: Theme.border
+                                border.width: Theme.borderW
                             }
                         }
                     }

--- a/OcchioOnniveggente/src/qml/components/ChatHistory.qml
+++ b/OcchioOnniveggente/src/qml/components/ChatHistory.qml
@@ -1,0 +1,19 @@
+import QtQuick 2.15
+import ".."
+import Theme 1.0
+import "."
+
+ListView {
+    id: root
+    property var historyModel
+    width: parent ? parent.width : 300
+    model: historyModel
+    spacing: 10
+    clip: true
+
+    delegate: ChatBubble {
+        width: root.width
+        text: model.content
+        fromUser: model.role === "user"
+    }
+}

--- a/OcchioOnniveggente/src/ui_controller.py
+++ b/OcchioOnniveggente/src/ui_controller.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from src.conversation import ConversationManager
 from src.ui_state import UIState
+from src.chat import ChatState
 
 
 class UIController:
@@ -37,6 +38,25 @@ class UIController:
     def set_conversation(self, conv: ConversationManager) -> None:
         self.state.conversation = conv
 
+    # convenience access to ChatState
+    @property
+    def chat_state(self) -> ChatState:
+        """Return the active :class:`ChatState`, creating one if needed."""
+        if self.state.conversation is None:
+            self.state.conversation = ConversationManager()
+        return self.state.conversation.chat
+
+    def submit_user_input(self, text: str) -> None:
+        """Append ``text`` to the chat history.
+
+        Both textual and transcribed vocal inputs should flow through this
+        single entry point so the rest of the application deals with a
+        unified conversation history.
+        """
+        if not text:
+            return
+        self.chat_state.push_user(text)
+
     # ------------------------------------------------------------------
     # audio reference
     @property
@@ -54,8 +74,6 @@ from typing import Any, Callable
 import yaml
 from openai import AsyncOpenAI
 
-from src.chat import ChatState
-from src.conversation import ConversationManager
 from src.config import get_openai_api_key
 from src.domain import validate_question
 from src.oracle import oracle_answer

--- a/OcchioOnniveggente/src/ui_qml.py
+++ b/OcchioOnniveggente/src/ui_qml.py
@@ -2,26 +2,91 @@
 from __future__ import annotations
 import sys
 from pathlib import Path
-from PySide6.QtCore import QObject, Slot, Signal, Property, QUrl
+from PySide6.QtCore import (
+    QObject,
+    Slot,
+    Signal,
+    Property,
+    QUrl,
+    QAbstractListModel,
+    QModelIndex,
+    Qt,
+)
 from PySide6.QtGui import QGuiApplication
 from PySide6.QtQml import QQmlApplicationEngine
 
+from src.ui_controller import UIController
+from src.chat import ChatState
+import logging
+
 ROOT = Path(__file__).resolve().parent
+
+
+class HistoryModel(QAbstractListModel):
+    ROLE_ROLE = Qt.UserRole + 1
+    CONTENT_ROLE = Qt.UserRole + 2
+
+    def __init__(self, chat: ChatState):
+        super().__init__()
+        self.chat = chat
+
+    def rowCount(self, parent: QModelIndex | None = None) -> int:  # type: ignore[override]
+        return len(self.chat.history)
+
+    def data(self, index: QModelIndex, role: int = Qt.DisplayRole):  # type: ignore[override]
+        if not index.isValid():
+            return None
+        msg = self.chat.history[index.row()]
+        if role == self.ROLE_ROLE:
+            return msg.get("role", "")
+        if role == self.CONTENT_ROLE:
+            return msg.get("content", "")
+        return None
+
+    def roleNames(self):  # type: ignore[override]
+        return {
+            self.ROLE_ROLE: b"role",
+            self.CONTENT_ROLE: b"content",
+        }
+
+    def refresh(self) -> None:
+        self.beginResetModel()
+        self.endResetModel()
+
 
 class Bridge(QObject):
     wakeWordRecognizedChanged = Signal()
+    logTextChanged = Signal(str)
 
-    def __init__(self):
+    def __init__(self, controller: UIController):
         super().__init__()
         self._wake = False
+        self.controller = controller
+        self._log_text = ""
+        self._history_model = HistoryModel(self.controller.chat_state)
+
+    @Property(QObject, constant=True)
+    def historyModel(self) -> QObject:
+        return self._history_model
 
     @Slot()
     def onMicTapped(self):
-        print("🎙️ Mic tapped (TODO: start/stop capture)")
+        # Voice input is treated the same as text once transcribed
+        self.controller.submit_user_input("[voice]")
+        self._history_model.refresh()
 
-    @Slot()
-    def onSendPressed(self):
-        print("💬 Send pressed (TODO: send text to backend)")
+    @Slot(str)
+    def sendText(self, text: str) -> None:
+        self.controller.submit_user_input(text)
+        self._history_model.refresh()
+
+    def appendLog(self, text: str) -> None:
+        self._log_text += text + "\n"
+        self.logTextChanged.emit(self._log_text)
+
+    @Property(str, notify=logTextChanged)
+    def logText(self) -> str:
+        return self._log_text
 
     @Property(bool, notify=wakeWordRecognizedChanged)
     def wakeWordRecognized(self):
@@ -33,10 +98,27 @@ class Bridge(QObject):
             self._wake = v
             self.wakeWordRecognizedChanged.emit()
 
+
+class _QtLogHandler(logging.Handler):
+    def __init__(self, bridge: Bridge):
+        super().__init__()
+        self.bridge = bridge
+
+    def emit(self, record: logging.LogRecord) -> None:
+        msg = self.format(record)
+        self.bridge.appendLog(msg)
+
+
 def main():
     app = QGuiApplication(sys.argv)
+    controller = UIController()
+    bridge = Bridge(controller)
+
+    logger = logging.getLogger("backend")
+    logger.setLevel(logging.INFO)
+    logger.addHandler(_QtLogHandler(bridge))
+
     engine = QQmlApplicationEngine()
-    bridge = Bridge()
     engine.rootContext().setContextProperty("Bridge", bridge)
     engine.addImportPath(str(ROOT / "qml"))
     engine.load(QUrl.fromLocalFile(str(ROOT / "qml" / "MainSciFi.qml")))


### PR DESCRIPTION
## Summary
- Display `ChatState.history` in a dedicated `ChatHistory` QML component
- Consolidate text and voice input controls and route to a single controller
- Show backend log messages in a separate TextArea

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adfaf3ab508327a640191a2ede74e0