### PR TITLE
feat: add service container interfaces and provider selection

### DIFF
--- a/OcchioOnniveggente/settings.yaml
+++ b/OcchioOnniveggente/settings.yaml
@@ -7,6 +7,10 @@ logging:
 
 debug: false
 
+stt_provider: local
+tts_provider: local
+llm_provider: openai
+
 
 compute:
   # Device di default per il calcolo (auto|cpu|cuda)

--- a/OcchioOnniveggente/src/chat.py
+++ b/OcchioOnniveggente/src/chat.py
@@ -8,6 +8,16 @@ work.
 from __future__ import annotations
 
 from .conversation import ChatState, summarize_history
+from .service_container import container
 
-__all__ = ["ChatState", "summarize_history"]
+
+def get_chat() -> ChatState:
+    """Return the shared :class:`ChatState` from the service container."""
+
+    if container.ui_state.conversation is None:
+        container.ui_state.conversation = ChatState()
+    return container.ui_state.conversation
+
+
+__all__ = ["ChatState", "summarize_history", "get_chat"]
 

--- a/OcchioOnniveggente/src/config.py
+++ b/OcchioOnniveggente/src/config.py
@@ -173,6 +173,10 @@ class PersonaConfig(BaseModel):
 class Settings(BaseModel):
     debug: bool = False
     stt_backend: Literal["openai", "whisper"] = "openai"
+    # Selettori dinamici dei provider per i servizi core
+    stt_provider: str = "local"
+    tts_provider: str = "local"
+    llm_provider: str = "openai"
     wakeword: Optional[str] = None
     openai: OpenAIConfig = OpenAIConfig()
     compute: ComputeConfig = ComputeConfig()

--- a/OcchioOnniveggente/src/openai_async.py
+++ b/OcchioOnniveggente/src/openai_async.py
@@ -110,3 +110,28 @@ def shutdown() -> None:  # pragma: no cover - compatibility stub
     """Previously closed the thread pool; now a no-op for compatibility."""
     return None
 
+
+from typing import Protocol, Any
+
+
+class LLMClient(Protocol):
+    """Minimal interface for language model clients."""
+
+    responses: Any
+
+
+class _ResponseWrapper:
+    def __init__(self, client: Any):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return run(self._client.responses.create, **kwargs)
+
+
+class OpenAILLMClient:
+    """Wrapper exposing a blocking interface for ``AsyncOpenAI``."""
+
+    def __init__(self, client: Any):
+        self.responses = _ResponseWrapper(client)
+
+

--- a/OcchioOnniveggente/src/ui_state.py
+++ b/OcchioOnniveggente/src/ui_state.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-from src.conversation import ConversationManager
+from .conversation import ConversationManager
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- define `SpeechToText`, `TextToSpeech`, and `LLMClient` interfaces and expose local implementations
- allow selecting STT, TTS, and LLM providers through settings and service container helpers
- resolve services via the container in oracle and chat utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adfea9d3408327af953f20c625bd30