### PR TITLE
feat: introduce event bus for async UI updates

### DIFF
--- a/OcchioOnniveggente/src/chat.py
+++ b/OcchioOnniveggente/src/chat.py
@@ -8,6 +8,32 @@ work.
 from __future__ import annotations
 
 from .conversation import ChatState, summarize_history
+from .event_bus import event_bus
 
-__all__ = ["ChatState", "summarize_history"]
+
+def publish_recording_started() -> None:
+    """Notify subscribers that audio recording has begun."""
+
+    event_bus.publish("recording_started")
+
+
+def publish_transcript(text: str) -> None:
+    """Publish a transcript for downstream consumers."""
+
+    event_bus.publish("transcript_ready", text)
+
+
+def publish_response(text: str) -> None:
+    """Publish a ready assistant response."""
+
+    event_bus.publish("response_ready", text)
+
+
+__all__ = [
+    "ChatState",
+    "summarize_history",
+    "publish_recording_started",
+    "publish_transcript",
+    "publish_response",
+]
 

--- a/OcchioOnniveggente/src/event_bus.py
+++ b/OcchioOnniveggente/src/event_bus.py
@@ -1,0 +1,45 @@
+import asyncio
+from collections import defaultdict
+from typing import Any, Callable, Awaitable, Dict, List
+
+
+class EventBus:
+    """Simple event bus built on top of :class:`asyncio.Queue`.
+
+    Publishers enqueue events via :meth:`publish` while subscribers register
+    callbacks with :meth:`subscribe`.  Callbacks may be normal callables or
+    coroutines.  If an asyncio event loop is running, coroutine callbacks are
+    scheduled on it, otherwise they are executed synchronously via
+    :func:`asyncio.run`.
+    """
+
+    def __init__(self) -> None:
+        self._listeners: Dict[str, List[Callable[..., Any]]] = defaultdict(list)
+        self._queue: asyncio.Queue[tuple[str, tuple[Any, ...], dict[str, Any]]] = (
+            asyncio.Queue()
+        )
+
+    def subscribe(self, event: str, callback: Callable[..., Any]) -> None:
+        """Register *callback* to be invoked when *event* is published."""
+
+        self._listeners[event].append(callback)
+
+    def publish(self, event: str, *args: Any, **kwargs: Any) -> None:
+        """Publish *event* with the provided arguments."""
+
+        self._queue.put_nowait((event, args, kwargs))
+        while not self._queue.empty():
+            name, a, kw = self._queue.get_nowait()
+            for cb in list(self._listeners.get(name, [])):
+                res = cb(*a, **kw)
+                if asyncio.iscoroutine(res):
+                    try:
+                        loop = asyncio.get_running_loop()
+                        loop.create_task(res)
+                    except RuntimeError:
+                        asyncio.run(res)
+
+
+event_bus = EventBus()
+
+__all__ = ["EventBus", "event_bus"]


### PR DESCRIPTION
## Summary
- add simple asyncio-based EventBus
- emit recording, transcript, and response events in chat and oracle helpers
- subscribe UI controller to event bus for conversation updates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adfeabfbdc8327b6d485afa610eb27