### PR TITLE
Persist conversation state with SQLite store

### DIFF
--- a/OcchioOnniveggente/DataBase/__init__.py
+++ b/OcchioOnniveggente/DataBase/__init__.py
@@ -1,0 +1,5 @@
+"""Database utilities for OcchioOnniveggente."""
+
+__all__ = [
+    "conversation_store",
+]

--- a/OcchioOnniveggente/DataBase/conversation_store.py
+++ b/OcchioOnniveggente/DataBase/conversation_store.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import numpy as np
+
+
+class ConversationStore:
+    """Simple SQLite-backed store for chat sessions."""
+
+    def __init__(self, db_path: str | Path = "chat_sessions.sqlite") -> None:
+        self.db_path = Path(db_path)
+        self.conn = sqlite3.connect(str(self.db_path))
+        self._create_schema()
+
+    def _create_schema(self) -> None:
+        with self.conn:
+            self.conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS sessions (
+                    session_id TEXT PRIMARY KEY,
+                    data TEXT NOT NULL
+                )
+                """
+            )
+
+    # --------------------------- persistence ---------------------------
+    def save_state(self, session_id: str, data: Dict[str, Any]) -> None:
+        """Persist *data* for ``session_id``."""
+        serial = json.dumps(data, default=self._serialize, ensure_ascii=False)
+        with self.conn:
+            self.conn.execute(
+                "INSERT OR REPLACE INTO sessions (session_id, data) VALUES (?, ?)",
+                (session_id, serial),
+            )
+
+    def load_state(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Load and return the data for ``session_id`` if present."""
+        cur = self.conn.execute(
+            "SELECT data FROM sessions WHERE session_id=?", (session_id,)
+        )
+        row = cur.fetchone()
+        if not row:
+            return None
+        data = json.loads(row[0])
+        if data.get("topic_emb") is not None:
+            data["topic_emb"] = np.array(data["topic_emb"], dtype=np.float32)
+        if data.get("persist_jsonl"):
+            data["persist_jsonl"] = Path(data["persist_jsonl"])
+        return data
+
+    # ------------------------------ utils ------------------------------
+    def _serialize(self, obj: Any) -> Any:
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        if isinstance(obj, Path):
+            return str(obj)
+        raise TypeError(f"Object of type {type(obj)!r} not serializable")
+
+
+__all__ = ["ConversationStore"]

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from OcchioOnniveggente.src.conversation import ConversationManager
+from OcchioOnniveggente.DataBase.conversation_store import ConversationStore
 
 
 def test_conversation_manager_tracks_and_summarizes():
@@ -15,3 +16,16 @@ def test_conversation_manager_tracks_and_summarizes():
     assert msgs[0]["role"] == "system"
     assert msgs[-1]["content"] == "a5"
     assert len(msgs) <= cm.max_history + 1
+
+
+def test_load_session_restores_state(tmp_path):
+    db = tmp_path / "conv.sqlite"
+    cm1 = ConversationManager(max_history=4, store=ConversationStore(db))
+    cm1.push_user("u1")
+    cm1.push_assistant("a1")
+    sid = cm1.chat.session_id
+
+    cm2 = ConversationManager(max_history=4, store=ConversationStore(db))
+    cm2.load_session(sid)
+    assert cm2.chat.history[0]["content"] == "u1"
+    assert cm2.chat.history[1]["content"] == "a1"


### PR DESCRIPTION
## Summary
- add `ConversationStore` module backed by SQLite for session persistence
- wire `ConversationManager` to save and load chat state via the store
- expose `load_session` and unique `session_id` generation for state restoration
- test session reload across instances

## Testing
- `pytest` *(fails: SyntaxError in existing `chat.py` during collection)*
- `pytest tests/test_conversation_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae14365e808327b0e1683163ef2400