### PR TITLE
Add documentation scaffolding with MkDocs and deployment examples

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  oracolo:
+    build: .
+    env_file:
+      - .env
+    ports:
+      - "8000:8000"

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,13 @@
+# API
+
+Questa sezione descrive i moduli principali dell'Oracolo.
+
+## `oracle.py`
+
+Pipeline principale STT → validazione → risposta LLM → TTS.
+
+## `local_audio.py`
+
+Utilità per TTS/STT locale e streaming a chunk.
+
+Per maggiori dettagli consulta i docstring nel codice sorgente.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,27 @@
+# Deploy
+
+## Requisiti hardware
+
+- CPU a 4 core
+- 8 GB di RAM
+- GPU opzionale per modelli più pesanti
+
+## Variabili d'ambiente
+
+Crea un file `.env` con le chiavi necessarie:
+
+```
+OPENAI_API_KEY=...
+```
+
+## Docker
+
+Usa il file `docker-compose.yml` di esempio nella radice del progetto:
+
+```bash
+docker-compose up --build
+```
+
+## Kubernetes
+
+Su Kubernetes crea un deployment basato sull'immagine Docker e monta il volume con `.env`.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,9 @@
+# FAQ
+
+**Posso usare Oracolo senza connessione Internet?**
+
+Sì, configurando backend locali per LLM e TTS/STT.
+
+**Come aggiungo nuovi documenti?**
+
+Usa `python scripts/ingest_docs.py --add percorso`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,12 @@
+# Panoramica
+
+Benvenuto nella documentazione di **Oracolo**, assistente vocale in italiano e inglese. Questo sito offre una panoramica del progetto, guide pratiche e riferimenti API.
+
+## Sezioni
+
+- [Installazione](install.md)
+- [API](api.md)
+- [FAQ](faq.md)
+- [Tutorial](tutorials/stt_tts.md)
+- [Deploy](deploy.md)
+- [Versionamento](versioning.md)

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,13 @@
+# Installazione
+
+```bash
+pip install oracolo
+```
+
+Per lo sviluppo:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+Assicurati di avere Python 3.10 o superiore.

--- a/docs/tutorials/document_ingestion.md
+++ b/docs/tutorials/document_ingestion.md
@@ -1,0 +1,13 @@
+# Ingestione documenti
+
+Per aggiungere file all'indice:
+
+```bash
+python scripts/ingest_docs.py --add DataBase
+```
+
+Per rigenerare l'indice:
+
+```bash
+python scripts/ingest_docs.py --reindex
+```

--- a/docs/tutorials/llm_config.md
+++ b/docs/tutorials/llm_config.md
@@ -1,0 +1,13 @@
+# Configurazione LLM locale
+
+Imposta l'opzione `llm_backend=local` nel tuo file `settings.yaml`:
+
+```yaml
+llm_backend: local
+```
+
+Avvia quindi l'Oracolo con:
+
+```bash
+python -m OcchioOnniveggente.src.oracle
+```

--- a/docs/tutorials/stt_tts.md
+++ b/docs/tutorials/stt_tts.md
@@ -1,0 +1,12 @@
+# STT e TTS locali
+
+Esempio minimale per usare i modelli locali:
+
+```python
+from OcchioOnniveggente.src.local_audio import transcribe, synthesize
+
+text = transcribe("audio.wav")
+print(text)
+
+synthesize("ciao", output="speech.wav")
+```

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,15 @@
+# Versionamento
+
+Per generare il changelog in modo automatico utilizza [towncrier](https://towncrier.readthedocs.io/):
+
+```bash
+pip install towncrier
+```
+
+Crea un frammento di notizia in `news/` e poi esegui:
+
+```bash
+towncrier build --version X.Y.Z
+```
+
+Il file `CHANGELOG.md` risultante va incluso nelle release.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,14 @@
+site_name: Oracolo
+nav:
+  - Overview: index.md
+  - Installation: install.md
+  - API: api.md
+  - FAQ: faq.md
+  - Tutorials:
+      - STT/TTS locale: tutorials/stt_tts.md
+      - Configurazione LLM: tutorials/llm_config.md
+      - Ingestione documenti: tutorials/document_ingestion.md
+  - Deploy: deploy.md
+  - Versionamento: versioning.md
+theme:
+  name: material


### PR DESCRIPTION
## Summary
- Set up MkDocs Material with overview, installation, API, FAQ and tutorials
- Add deployment guide covering Docker/Kubernetes, hardware requirements and env vars
- Document versioning workflow using towncrier and provide example docker-compose file

## Testing
- `pytest` *(fails: ImportError: attempted relative import beyond top-level package)*

------
https://chatgpt.com/codex/tasks/task_e_68ae35e90ecc83278a46a7d71eff4d50