### PR TITLE
feat: add plugin registry and modular frontends

### DIFF
--- a/OcchioOnniveggente/src/audio.py
+++ b/OcchioOnniveggente/src/audio.py
@@ -434,3 +434,25 @@ class LocalTextToSpeech:
         tts_local(text, tmp, lang=lang)
         return tmp.read_bytes()
 
+
+# Plugin registration -------------------------------------------------------
+
+def create_local_stt(container: "ServiceContainer") -> SpeechToText:
+    """Factory for the built-in local STT backend."""
+    return LocalSpeechToText()
+
+
+def create_local_tts(container: "ServiceContainer") -> TextToSpeech:
+    """Factory for the built-in local TTS backend."""
+    return LocalTextToSpeech()
+
+
+try:  # pragma: no cover - registry may not be available during docs build
+    from .plugins import register_stt, register_tts
+    from .service_container import ServiceContainer  # for type checking
+
+    register_stt("local", create_local_stt)
+    register_tts("local", create_local_tts)
+except Exception:  # pragma: no cover - defensive
+    pass
+

--- a/OcchioOnniveggente/src/frontend.py
+++ b/OcchioOnniveggente/src/frontend.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Reusable front-end components for CLI and web interfaces."""
+
+from typing import Protocol
+
+
+class Frontend(Protocol):
+    """Minimal interface for a front-end component."""
+
+    def run(self) -> None:
+        """Start the user interface."""
+        ...
+
+
+class CLIFrontend:
+    """Very small wrapper around console helpers."""
+
+    def run(self) -> None:  # pragma: no cover - simple passthrough
+        from .cli import _ensure_utf8_stdout, oracle_greeting
+
+        _ensure_utf8_stdout()
+        print(oracle_greeting("it"))
+
+
+class WebFrontend:
+    """Wrapper launching the Flask web application."""
+
+    def __init__(self) -> None:
+        from .webapp import create_app
+
+        self.app = create_app()
+
+    def run(self) -> None:  # pragma: no cover - starts server
+        self.app.run()
+
+
+__all__ = ["Frontend", "CLIFrontend", "WebFrontend"]

--- a/OcchioOnniveggente/src/openai_async.py
+++ b/OcchioOnniveggente/src/openai_async.py
@@ -135,3 +135,17 @@ class OpenAILLMClient:
         self.responses = _ResponseWrapper(client)
 
 
+def create_openai_llm(container: "ServiceContainer") -> LLMClient:
+    """Factory returning an :class:`OpenAILLMClient` bound to ``container``."""
+    return OpenAILLMClient(container.openai_client())
+
+
+try:  # pragma: no cover - registry may not be available during docs build
+    from .plugins import register_llm
+    from .service_container import ServiceContainer
+
+    register_llm("openai", create_openai_llm)
+except Exception:  # pragma: no cover - defensive
+    pass
+
+

--- a/OcchioOnniveggente/src/plugins.py
+++ b/OcchioOnniveggente/src/plugins.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+"""Simple plugin registry for STT, TTS and LLM providers.
+
+Plugins can be registered via :func:`register_stt`, :func:`register_tts` and
+:func:`register_llm`.  Third party packages may also expose entry points using
+``oracolo.stt``, ``oracolo.tts`` or ``oracolo.llm`` groups.  Each entry point is
+expected to provide a factory callable accepting a
+:class:`~OcchioOnniveggente.src.service_container.ServiceContainer` instance and
+returning the concrete backend implementation.
+"""
+
+from importlib.metadata import entry_points
+from typing import TYPE_CHECKING, Callable, Dict
+
+if TYPE_CHECKING:  # pragma: no cover - hints only
+    from .audio import SpeechToText, TextToSpeech
+    from .openai_async import LLMClient
+    from .service_container import ServiceContainer
+
+# Factory type aliases -----------------------------------------------------
+STTFactory = Callable[["ServiceContainer"], "SpeechToText"]
+TTSFactory = Callable[["ServiceContainer"], "TextToSpeech"]
+LLMFactory = Callable[["ServiceContainer"], "LLMClient"]
+
+# Registries ---------------------------------------------------------------
+_stt_registry: Dict[str, STTFactory] = {}
+_tts_registry: Dict[str, TTSFactory] = {}
+_llm_registry: Dict[str, LLMFactory] = {}
+
+_ep_loaded = False
+
+
+def register_stt(name: str, factory: STTFactory) -> None:
+    """Register a speech-to-text provider factory under ``name``."""
+    _stt_registry[name] = factory
+
+
+def register_tts(name: str, factory: TTSFactory) -> None:
+    """Register a text-to-speech provider factory under ``name``."""
+    _tts_registry[name] = factory
+
+
+def register_llm(name: str, factory: LLMFactory) -> None:
+    """Register a language model provider factory under ``name``."""
+    _llm_registry[name] = factory
+
+
+# Entry point loading ------------------------------------------------------
+
+def _load_entry_points() -> None:
+    global _ep_loaded
+    if _ep_loaded:
+        return
+    _ep_loaded = True
+    eps = entry_points()
+    for ep in eps.select(group="oracolo.stt"):
+        register_stt(ep.name, ep.load())
+    for ep in eps.select(group="oracolo.tts"):
+        register_tts(ep.name, ep.load())
+    for ep in eps.select(group="oracolo.llm"):
+        register_llm(ep.name, ep.load())
+
+
+# Factory helpers ----------------------------------------------------------
+
+def create_stt(name: str, container: "ServiceContainer"):
+    _load_entry_points()
+    factory = _stt_registry.get(name)
+    if factory is None:
+        raise ValueError(f"Unsupported STT provider: {name}")
+    return factory(container)
+
+
+def create_tts(name: str, container: "ServiceContainer"):
+    _load_entry_points()
+    factory = _tts_registry.get(name)
+    if factory is None:
+        raise ValueError(f"Unsupported TTS provider: {name}")
+    return factory(container)
+
+
+def create_llm(name: str, container: "ServiceContainer"):
+    _load_entry_points()
+    factory = _llm_registry.get(name)
+    if factory is None:
+        raise ValueError(f"Unsupported LLM provider: {name}")
+    return factory(container)
+
+
+__all__ = [
+    "register_stt",
+    "register_tts",
+    "register_llm",
+    "create_stt",
+    "create_tts",
+    "create_llm",
+]

--- a/OcchioOnniveggente/src/service_container.py
+++ b/OcchioOnniveggente/src/service_container.py
@@ -12,8 +12,9 @@ from dataclasses import dataclass, field
 from typing import Any
 import asyncio
 
-from .audio import SpeechToText, TextToSpeech, LocalSpeechToText, LocalTextToSpeech
-from .openai_async import LLMClient, OpenAILLMClient
+from .audio import SpeechToText, TextToSpeech
+from .openai_async import LLMClient
+from .plugins import create_stt, create_tts, create_llm
 from .conversation import ConversationManager
 
 import atexit
@@ -93,28 +94,19 @@ class ServiceContainer:
     def speech_to_text(self) -> SpeechToText:
         if self._stt_service is None:
             provider = getattr(self.settings, "stt_provider", "local")
-            if provider == "local":
-                self._stt_service = LocalSpeechToText()
-            else:
-                raise ValueError(f"Unsupported STT provider: {provider}")
+            self._stt_service = create_stt(provider, self)
         return self._stt_service
 
     def text_to_speech(self) -> TextToSpeech:
         if self._tts_service is None:
             provider = getattr(self.settings, "tts_provider", "local")
-            if provider == "local":
-                self._tts_service = LocalTextToSpeech()
-            else:
-                raise ValueError(f"Unsupported TTS provider: {provider}")
+            self._tts_service = create_tts(provider, self)
         return self._tts_service
 
     def llm_client(self) -> LLMClient:
         if self._llm_service is None:
             provider = getattr(self.settings, "llm_provider", "openai")
-            if provider == "openai":
-                self._llm_service = OpenAILLMClient(self.openai_client())
-            else:
-                raise ValueError(f"Unsupported LLM provider: {provider}")
+            self._llm_service = create_llm(provider, self)
         return self._llm_service
 
     # ------------------------------------------------------------------

--- a/OcchioOnniveggente/src/webapp.py
+++ b/OcchioOnniveggente/src/webapp.py
@@ -10,57 +10,60 @@ from .service_container import container
 from .oracle import oracle_answer, transcribe
 from .metrics import metrics_endpoint, health_endpoint
 
-app = Flask(__name__, template_folder='templates', static_folder='static')
 
-conv = container.conversation_manager
-queue = container.message_queue
+def create_app() -> Flask:
+    """Create and configure the Flask application."""
+
+    app = Flask(__name__, template_folder="templates", static_folder="static")
+
+    conv = container.conversation_manager
+    queue = container.message_queue
+
+    @app.get("/docs")
+    def docs() -> str:
+        """Render the documentation page."""
+        return render_template("docs.html")
+
+    @app.post("/chat")
+    def chat_endpoint() -> "flask.Response":
+        data = request.get_json(force=True) or {}
+        message = data.get("message", "")
+        if message:
+            asyncio.run(queue.put(message))
+            answer, _ = oracle_answer(message, "it", conv=conv)
+        else:
+            answer = ""
+        return jsonify({"response": answer})
+
+    @app.post("/voice")
+    def voice_endpoint() -> "flask.Response":
+        if "audio" not in request.files:
+            return jsonify({"error": "missing audio"}), 400
+        file = request.files["audio"]
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".wav")
+        file.save(tmp.name)
+        text = asyncio.run(transcribe(Path(tmp.name), conv=conv))
+        asyncio.run(queue.put(text))
+        answer, _ = oracle_answer(text, "it", conv=conv)
+        return jsonify({"transcript": text, "response": answer})
+
+    @app.get("/logs")
+    def logs_endpoint() -> "flask.Response":
+        return jsonify(conv.messages_for_llm() if conv else [])
+
+    @app.get("/metrics")
+    def metrics() -> "flask.Response":
+        return metrics_endpoint()
+
+    @app.get("/healthz")
+    def health() -> "flask.Response":
+        return health_endpoint()
+
+    return app
 
 
-@app.get('/docs')
-def docs() -> str:
-    """Render the documentation page."""
-    return render_template('docs.html')
+app = create_app()
 
 
-@app.post('/chat')
-def chat_endpoint() -> 'flask.Response':
-    data = request.get_json(force=True) or {}
-    message = data.get('message', '')
-    if message:
-        asyncio.run(queue.put(message))
-        answer, _ = oracle_answer(message, 'it', conv=conv)
-    else:
-        answer = ''
-    return jsonify({'response': answer})
-
-
-@app.post('/voice')
-def voice_endpoint() -> 'flask.Response':
-    if 'audio' not in request.files:
-        return jsonify({'error': 'missing audio'}), 400
-    file = request.files['audio']
-    tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.wav')
-    file.save(tmp.name)
-    text = asyncio.run(transcribe(Path(tmp.name), conv=conv))
-    asyncio.run(queue.put(text))
-    answer, _ = oracle_answer(text, 'it', conv=conv)
-    return jsonify({'transcript': text, 'response': answer})
-
-
-@app.get('/logs')
-def logs_endpoint() -> 'flask.Response':
-    return jsonify(conv.messages_for_llm() if conv else [])
-
-
-@app.get('/metrics')
-def metrics() -> 'flask.Response':
-    return metrics_endpoint()
-
-
-@app.get('/healthz')
-def health() -> 'flask.Response':
-    return health_endpoint()
-
-
-if __name__ == '__main__':  # pragma: no cover - manual invocation helper
+if __name__ == "__main__":  # pragma: no cover - manual invocation helper
     app.run(debug=True)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,28 @@ OcchioOnniveggente/
 └── tests/            # test automatici (pytest)
 ```
 
+## Estensibilità e modularità
+
+### Plugin backend
+
+Registri di plugin consentono ora di estendere i provider STT/TTS/LLM tramite
+entry point Python.  I backend predefiniti sono registrati automaticamente ma è
+possibile aggiungerne altri definendo gli entry point `oracolo.stt`,
+`oracolo.tts` e `oracolo.llm`.
+
+### GUI modulare
+
+Il front‑end è stato separato in componenti riusabili che espongono un'unica
+API `run()`.  I wrapper `CLIFrontend` e `WebFrontend` permettono di integrare
+facilmente l'interfaccia a riga di comando o quella web/REST.
+
+### Configurazione
+
+Lo schema completo delle impostazioni è generabile tramite lo script
+`scripts/generate_settings_schema.py` che produce
+`docs/settings.schema.json` con tutti i parametri validi e i relativi valori di
+default.
+
 ## Domande fuori tema
 
 Il file `data/domande_oracolo.json` contiene anche quesiti marcati con

--- a/docs/settings.schema.json
+++ b/docs/settings.schema.json
@@ -1,0 +1,1042 @@
+{
+  "$defs": {
+    "AudioConfig": {
+      "properties": {
+        "sample_rate": {
+          "default": 24000,
+          "title": "Sample Rate",
+          "type": "integer"
+        },
+        "ask_seconds": {
+          "default": 10,
+          "title": "Ask Seconds",
+          "type": "integer"
+        },
+        "input_wav": {
+          "default": "data/temp/input.wav",
+          "title": "Input Wav",
+          "type": "string"
+        },
+        "output_wav": {
+          "default": "data/temp/answer.wav",
+          "title": "Output Wav",
+          "type": "string"
+        },
+        "input_device": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Input Device"
+        },
+        "output_device": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Output Device"
+        },
+        "barge_rms_threshold": {
+          "default": 0.25,
+          "title": "Barge Rms Threshold",
+          "type": "number"
+        },
+        "denoise": {
+          "default": false,
+          "title": "Denoise",
+          "type": "boolean"
+        },
+        "echo_cancel": {
+          "default": false,
+          "title": "Echo Cancel",
+          "type": "boolean"
+        }
+      },
+      "title": "AudioConfig",
+      "type": "object"
+    },
+    "ChatConfig": {
+      "properties": {
+        "inactivity_timeout_s": {
+          "default": 60,
+          "title": "Inactivity Timeout S",
+          "type": "integer"
+        },
+        "remember_turns": {
+          "default": 8,
+          "title": "Remember Turns",
+          "type": "integer"
+        },
+        "pinned": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Pinned",
+          "type": "array"
+        },
+        "summary_model": {
+          "default": "gpt-4o-mini",
+          "title": "Summary Model",
+          "type": "string"
+        },
+        "summary_max_tokens": {
+          "default": 256,
+          "title": "Summary Max Tokens",
+          "type": "integer"
+        },
+        "tone": {
+          "default": "informal",
+          "enum": [
+            "formal",
+            "informal"
+          ],
+          "title": "Tone",
+          "type": "string"
+        }
+      },
+      "title": "ChatConfig",
+      "type": "object"
+    },
+    "ComputeConfig": {
+      "properties": {
+        "device": {
+          "default": "auto",
+          "enum": [
+            "auto",
+            "cpu",
+            "cuda"
+          ],
+          "title": "Device",
+          "type": "string"
+        },
+        "use_onnx": {
+          "default": false,
+          "title": "Use Onnx",
+          "type": "boolean"
+        },
+        "device_concurrency": {
+          "default": 1,
+          "title": "Device Concurrency",
+          "type": "integer"
+        },
+        "stt": {
+          "$ref": "#/$defs/ComputeModuleConfig",
+          "default": {
+            "device": "auto",
+            "precision": "fp16",
+            "batch_interval": 100,
+            "max_batch_size": 4
+          }
+        },
+        "llm": {
+          "$ref": "#/$defs/ComputeModuleConfig",
+          "default": {
+            "device": "auto",
+            "precision": "fp16",
+            "batch_interval": 100,
+            "max_batch_size": 4
+          }
+        },
+        "tts": {
+          "$ref": "#/$defs/ComputeModuleConfig",
+          "default": {
+            "device": "auto",
+            "precision": "fp16",
+            "batch_interval": 100,
+            "max_batch_size": 4
+          }
+        }
+      },
+      "title": "ComputeConfig",
+      "type": "object"
+    },
+    "ComputeModuleConfig": {
+      "properties": {
+        "device": {
+          "default": "auto",
+          "enum": [
+            "auto",
+            "cpu",
+            "cuda"
+          ],
+          "title": "Device",
+          "type": "string"
+        },
+        "precision": {
+          "default": "fp16",
+          "enum": [
+            "fp32",
+            "fp16",
+            "bf16",
+            "int4"
+          ],
+          "title": "Precision",
+          "type": "string"
+        },
+        "batch_interval": {
+          "default": 100,
+          "title": "Batch Interval",
+          "type": "integer"
+        },
+        "max_batch_size": {
+          "default": 4,
+          "title": "Max Batch Size",
+          "type": "integer"
+        }
+      },
+      "title": "ComputeModuleConfig",
+      "type": "object"
+    },
+    "DomainConfig": {
+      "properties": {
+        "enabled": {
+          "default": true,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "profile": {
+          "default": "museo",
+          "title": "Profile",
+          "type": "string"
+        },
+        "topic": {
+          "default": "",
+          "title": "Topic",
+          "type": "string"
+        },
+        "keywords": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Keywords",
+          "type": "array"
+        },
+        "kw_min_overlap": {
+          "default": 0.04,
+          "title": "Kw Min Overlap",
+          "type": "number"
+        },
+        "emb_min_sim": {
+          "default": 0.22,
+          "title": "Emb Min Sim",
+          "type": "number"
+        },
+        "rag_min_hits": {
+          "default": 1,
+          "title": "Rag Min Hits",
+          "type": "integer"
+        },
+        "weights": {
+          "additionalProperties": {
+            "type": "number"
+          },
+          "title": "Weights",
+          "type": "object"
+        },
+        "accept_threshold": {
+          "default": 0.65,
+          "title": "Accept Threshold",
+          "type": "number"
+        },
+        "clarify_margin": {
+          "default": 0.1,
+          "title": "Clarify Margin",
+          "type": "number"
+        },
+        "profiles": {
+          "additionalProperties": {
+            "$ref": "#/$defs/DomainProfileConfig"
+          },
+          "title": "Profiles",
+          "type": "object"
+        }
+      },
+      "title": "DomainConfig",
+      "type": "object"
+    },
+    "DomainProfileConfig": {
+      "properties": {
+        "keywords": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Keywords",
+          "type": "array"
+        },
+        "weights": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "number"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Weights"
+        },
+        "accept_threshold": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Accept Threshold"
+        },
+        "clarify_margin": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Clarify Margin"
+        }
+      },
+      "title": "DomainProfileConfig",
+      "type": "object"
+    },
+    "FilterConfig": {
+      "properties": {
+        "mode": {
+          "default": "block",
+          "enum": [
+            "block",
+            "mask"
+          ],
+          "title": "Mode",
+          "type": "string"
+        }
+      },
+      "title": "FilterConfig",
+      "type": "object"
+    },
+    "LightingConfig": {
+      "properties": {
+        "mode": {
+          "default": "sacn",
+          "enum": [
+            "sacn",
+            "wled"
+          ],
+          "title": "Mode",
+          "type": "string"
+        },
+        "sacn": {
+          "$ref": "#/$defs/SacnConfig",
+          "default": {
+            "universe": 1,
+            "destination_ip": "192.168.1.50",
+            "rgb_channels": [
+              1,
+              2,
+              3
+            ],
+            "idle_level": 10,
+            "peak_level": 255
+          }
+        },
+        "wled": {
+          "$ref": "#/$defs/WledConfig",
+          "default": {
+            "host": "192.168.1.77"
+          }
+        }
+      },
+      "title": "LightingConfig",
+      "type": "object"
+    },
+    "OpenAIConfig": {
+      "properties": {
+        "api_key": {
+          "default": "",
+          "title": "Api Key",
+          "type": "string"
+        },
+        "stt_model": {
+          "default": "gpt-4o-mini-transcribe",
+          "title": "Stt Model",
+          "type": "string"
+        },
+        "llm_model": {
+          "default": "gpt-5-mini",
+          "title": "Llm Model",
+          "type": "string"
+        },
+        "tts_model": {
+          "default": "gpt-4o-mini-tts",
+          "title": "Tts Model",
+          "type": "string"
+        },
+        "tts_voice": {
+          "default": "alloy",
+          "title": "Tts Voice",
+          "type": "string"
+        },
+        "embed_model": {
+          "default": "text-embedding-3-large",
+          "title": "Embed Model",
+          "type": "string"
+        },
+        "max_workers": {
+          "default": 4,
+          "title": "Max Workers",
+          "type": "integer"
+        }
+      },
+      "title": "OpenAIConfig",
+      "type": "object"
+    },
+    "PaletteItem": {
+      "properties": {
+        "rgb": {
+          "maxItems": 3,
+          "minItems": 3,
+          "prefixItems": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "title": "Rgb",
+          "type": "array"
+        },
+        "style": {
+          "title": "Style",
+          "type": "string"
+        }
+      },
+      "required": [
+        "rgb",
+        "style"
+      ],
+      "title": "PaletteItem",
+      "type": "object"
+    },
+    "PersonaConfig": {
+      "properties": {
+        "current": {
+          "default": "standard",
+          "title": "Current",
+          "type": "string"
+        },
+        "profiles": {
+          "additionalProperties": {
+            "$ref": "#/$defs/PersonaProfile"
+          },
+          "title": "Profiles",
+          "type": "object"
+        }
+      },
+      "title": "PersonaConfig",
+      "type": "object"
+    },
+    "PersonaProfile": {
+      "properties": {
+        "tone": {
+          "default": "neutro",
+          "title": "Tone",
+          "type": "string"
+        },
+        "style": {
+          "default": "formale",
+          "title": "Style",
+          "type": "string"
+        }
+      },
+      "title": "PersonaProfile",
+      "type": "object"
+    },
+    "RealtimeAudioConfig": {
+      "properties": {
+        "chunk_ms": {
+          "default": 20,
+          "title": "Chunk Ms",
+          "type": "integer"
+        },
+        "start_level": {
+          "default": 300,
+          "title": "Start Level",
+          "type": "integer"
+        },
+        "end_sil_ms": {
+          "default": 700,
+          "title": "End Sil Ms",
+          "type": "integer"
+        },
+        "max_utt_ms": {
+          "default": 15000,
+          "title": "Max Utt Ms",
+          "type": "integer"
+        }
+      },
+      "title": "RealtimeAudioConfig",
+      "type": "object"
+    },
+    "RealtimeConfig": {
+      "properties": {
+        "barge_in_threshold": {
+          "default": 0.55,
+          "title": "Barge In Threshold",
+          "type": "number"
+        },
+        "ducking_db": {
+          "default": -12.0,
+          "title": "Ducking Db",
+          "type": "number"
+        },
+        "cpu_workers": {
+          "default": 4,
+          "title": "Cpu Workers",
+          "type": "integer"
+        },
+        "gpu_workers": {
+          "default": 1,
+          "title": "Gpu Workers",
+          "type": "integer"
+        }
+      },
+      "title": "RealtimeConfig",
+      "type": "object"
+    },
+    "RecordingConfig": {
+      "properties": {
+        "mode": {
+          "default": "vad",
+          "enum": [
+            "vad",
+            "timed"
+          ],
+          "title": "Mode",
+          "type": "string"
+        },
+        "timed_seconds": {
+          "default": 10,
+          "title": "Timed Seconds",
+          "type": "integer"
+        },
+        "fallback_to_timed": {
+          "default": false,
+          "title": "Fallback To Timed",
+          "type": "boolean"
+        },
+        "min_speech_level": {
+          "default": 0.02,
+          "title": "Min Speech Level",
+          "type": "number"
+        },
+        "hold_off_after_tts_ms": {
+          "default": 500,
+          "title": "Hold Off After Tts Ms",
+          "type": "integer"
+        },
+        "use_webrtcvad": {
+          "default": true,
+          "title": "Use Webrtcvad",
+          "type": "boolean"
+        },
+        "vad_sensitivity": {
+          "default": 2,
+          "title": "Vad Sensitivity",
+          "type": "integer"
+        }
+      },
+      "title": "RecordingConfig",
+      "type": "object"
+    },
+    "RetrievalConfig": {
+      "properties": {
+        "hybrid": {
+          "default": true,
+          "title": "Hybrid",
+          "type": "boolean"
+        },
+        "rerank": {
+          "default": true,
+          "title": "Rerank",
+          "type": "boolean"
+        },
+        "max_chunks": {
+          "default": 6,
+          "title": "Max Chunks",
+          "type": "integer"
+        },
+        "chunk_strategy": {
+          "default": "semantic",
+          "enum": [
+            "semantic",
+            "fixed_overlap"
+          ],
+          "title": "Chunk Strategy",
+          "type": "string"
+        }
+      },
+      "title": "RetrievalConfig",
+      "type": "object"
+    },
+    "SacnConfig": {
+      "properties": {
+        "universe": {
+          "default": 1,
+          "title": "Universe",
+          "type": "integer"
+        },
+        "destination_ip": {
+          "title": "Destination Ip",
+          "type": "string"
+        },
+        "rgb_channels": {
+          "items": {
+            "type": "integer"
+          },
+          "title": "Rgb Channels",
+          "type": "array"
+        },
+        "idle_level": {
+          "default": 10,
+          "title": "Idle Level",
+          "type": "integer"
+        },
+        "peak_level": {
+          "default": 255,
+          "title": "Peak Level",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "destination_ip",
+        "rgb_channels"
+      ],
+      "title": "SacnConfig",
+      "type": "object"
+    },
+    "VadConfig": {
+      "properties": {
+        "frame_ms": {
+          "default": 30,
+          "title": "Frame Ms",
+          "type": "integer"
+        },
+        "start_ms": {
+          "default": 200,
+          "title": "Start Ms",
+          "type": "integer"
+        },
+        "end_ms": {
+          "default": 800,
+          "title": "End Ms",
+          "type": "integer"
+        },
+        "max_ms": {
+          "default": 15000,
+          "title": "Max Ms",
+          "type": "integer"
+        },
+        "preroll_ms": {
+          "default": 300,
+          "title": "Preroll Ms",
+          "type": "integer"
+        },
+        "noise_window_ms": {
+          "default": 1000,
+          "title": "Noise Window Ms",
+          "type": "integer"
+        },
+        "start_mult": {
+          "default": 1.8,
+          "title": "Start Mult",
+          "type": "number"
+        },
+        "end_mult": {
+          "default": 1.3,
+          "title": "End Mult",
+          "type": "number"
+        },
+        "base_start": {
+          "default": 0.006,
+          "title": "Base Start",
+          "type": "number"
+        },
+        "base_end": {
+          "default": 0.0035,
+          "title": "Base End",
+          "type": "number"
+        }
+      },
+      "title": "VadConfig",
+      "type": "object"
+    },
+    "WakeConfig": {
+      "properties": {
+        "enabled": {
+          "default": true,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "single_turn": {
+          "default": false,
+          "title": "Single Turn",
+          "type": "boolean"
+        },
+        "idle_timeout": {
+          "default": 60.0,
+          "title": "Idle Timeout",
+          "type": "number"
+        },
+        "it_phrases": {
+          "items": {
+            "type": "string"
+          },
+          "title": "It Phrases",
+          "type": "array"
+        },
+        "en_phrases": {
+          "items": {
+            "type": "string"
+          },
+          "title": "En Phrases",
+          "type": "array"
+        }
+      },
+      "title": "WakeConfig",
+      "type": "object"
+    },
+    "WledConfig": {
+      "properties": {
+        "host": {
+          "title": "Host",
+          "type": "string"
+        }
+      },
+      "required": [
+        "host"
+      ],
+      "title": "WledConfig",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "debug": {
+      "default": false,
+      "title": "Debug",
+      "type": "boolean"
+    },
+    "stt_backend": {
+      "default": "openai",
+      "enum": [
+        "openai",
+        "whisper"
+      ],
+      "title": "Stt Backend",
+      "type": "string"
+    },
+    "stt_provider": {
+      "default": "local",
+      "title": "Stt Provider",
+      "type": "string"
+    },
+    "tts_provider": {
+      "default": "local",
+      "title": "Tts Provider",
+      "type": "string"
+    },
+    "llm_provider": {
+      "default": "openai",
+      "title": "Llm Provider",
+      "type": "string"
+    },
+    "wakeword": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Wakeword"
+    },
+    "openai": {
+      "$ref": "#/$defs/OpenAIConfig",
+      "default": {
+        "api_key": "",
+        "stt_model": "gpt-4o-mini-transcribe",
+        "llm_model": "gpt-5-mini",
+        "tts_model": "gpt-4o-mini-tts",
+        "tts_voice": "alloy",
+        "embed_model": "text-embedding-3-large",
+        "max_workers": 4
+      }
+    },
+    "compute": {
+      "$ref": "#/$defs/ComputeConfig",
+      "default": {
+        "device": "auto",
+        "use_onnx": false,
+        "device_concurrency": 1,
+        "stt": {
+          "batch_interval": 100,
+          "device": "auto",
+          "max_batch_size": 4,
+          "precision": "fp16"
+        },
+        "llm": {
+          "batch_interval": 100,
+          "device": "auto",
+          "max_batch_size": 4,
+          "precision": "fp16"
+        },
+        "tts": {
+          "batch_interval": 100,
+          "device": "auto",
+          "max_batch_size": 4,
+          "precision": "fp16"
+        }
+      }
+    },
+    "audio": {
+      "$ref": "#/$defs/AudioConfig",
+      "default": {
+        "sample_rate": 24000,
+        "ask_seconds": 10,
+        "input_wav": "data/temp/input.wav",
+        "output_wav": "data/temp/answer.wav",
+        "input_device": null,
+        "output_device": null,
+        "barge_rms_threshold": 0.25,
+        "denoise": false,
+        "echo_cancel": false
+      }
+    },
+    "recording": {
+      "$ref": "#/$defs/RecordingConfig",
+      "default": {
+        "mode": "vad",
+        "timed_seconds": 10,
+        "fallback_to_timed": false,
+        "min_speech_level": 0.02,
+        "hold_off_after_tts_ms": 500,
+        "use_webrtcvad": true,
+        "vad_sensitivity": 2
+      }
+    },
+    "vad": {
+      "$ref": "#/$defs/VadConfig",
+      "default": {
+        "frame_ms": 30,
+        "start_ms": 200,
+        "end_ms": 800,
+        "max_ms": 15000,
+        "preroll_ms": 300,
+        "noise_window_ms": 1000,
+        "start_mult": 1.8,
+        "end_mult": 1.3,
+        "base_start": 0.006,
+        "base_end": 0.0035
+      }
+    },
+    "filter": {
+      "$ref": "#/$defs/FilterConfig",
+      "default": {
+        "mode": "block"
+      }
+    },
+    "lighting": {
+      "$ref": "#/$defs/LightingConfig",
+      "default": {
+        "mode": "sacn",
+        "sacn": {
+          "destination_ip": "192.168.1.50",
+          "idle_level": 10,
+          "peak_level": 255,
+          "rgb_channels": [
+            1,
+            2,
+            3
+          ],
+          "universe": 1
+        },
+        "wled": {
+          "host": "192.168.1.77"
+        }
+      }
+    },
+    "palette_keywords": {
+      "additionalProperties": {
+        "$ref": "#/$defs/PaletteItem"
+      },
+      "title": "Palette Keywords",
+      "type": "object"
+    },
+    "oracle_system": {
+      "default": "",
+      "title": "Oracle System",
+      "type": "string"
+    },
+    "oracle_policy": {
+      "default": "",
+      "title": "Oracle Policy",
+      "type": "string"
+    },
+    "answer_mode": {
+      "default": "detailed",
+      "enum": [
+        "detailed",
+        "concise"
+      ],
+      "title": "Answer Mode",
+      "type": "string"
+    },
+    "persona": {
+      "$ref": "#/$defs/PersonaConfig",
+      "default": {
+        "current": "standard",
+        "profiles": {
+          "standard": {
+            "style": "formale",
+            "tone": "neutro"
+          }
+        }
+      }
+    },
+    "docstore_path": {
+      "default": "data/docstore",
+      "title": "Docstore Path",
+      "type": "string"
+    },
+    "retrieval_top_k": {
+      "default": 3,
+      "title": "Retrieval Top K",
+      "type": "integer"
+    },
+    "wake": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/WakeConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": {
+        "enabled": true,
+        "single_turn": false,
+        "idle_timeout": 60.0,
+        "it_phrases": [
+          "ciao oracolo",
+          "ehi oracolo",
+          "salve oracolo",
+          "ciao, oracolo"
+        ],
+        "en_phrases": [
+          "hello oracle",
+          "hey oracle",
+          "hi oracle",
+          "hello, oracle"
+        ]
+      }
+    },
+    "domain": {
+      "$ref": "#/$defs/DomainConfig",
+      "default": {
+        "enabled": true,
+        "profile": "museo",
+        "topic": "",
+        "keywords": [],
+        "kw_min_overlap": 0.04,
+        "emb_min_sim": 0.22,
+        "rag_min_hits": 1,
+        "weights": {
+          "emb": 0.2,
+          "kw": 0.6,
+          "rag": 0.2
+        },
+        "accept_threshold": 0.65,
+        "clarify_margin": 0.1,
+        "profiles": {}
+      }
+    },
+    "retrieval": {
+      "$ref": "#/$defs/RetrievalConfig",
+      "default": {
+        "hybrid": true,
+        "rerank": true,
+        "max_chunks": 6,
+        "chunk_strategy": "semantic"
+      }
+    },
+    "chat": {
+      "$ref": "#/$defs/ChatConfig",
+      "default": {
+        "inactivity_timeout_s": 60,
+        "remember_turns": 8,
+        "pinned": [],
+        "summary_model": "gpt-4o-mini",
+        "summary_max_tokens": 256,
+        "tone": "informal"
+      }
+    },
+    "realtime": {
+      "$ref": "#/$defs/RealtimeConfig",
+      "default": {
+        "barge_in_threshold": 0.55,
+        "ducking_db": -12.0,
+        "cpu_workers": 4,
+        "gpu_workers": 1
+      }
+    },
+    "realtime_audio": {
+      "$ref": "#/$defs/RealtimeAudioConfig",
+      "default": {
+        "chunk_ms": 20,
+        "start_level": 300,
+        "end_sil_ms": 700,
+        "max_utt_ms": 15000
+      }
+    },
+    "cache_dir": {
+      "default": "data/cache",
+      "title": "Cache Dir",
+      "type": "string"
+    },
+    "cache_ttl": {
+      "default": 3600,
+      "title": "Cache Ttl",
+      "type": "integer"
+    }
+  },
+  "title": "Settings",
+  "type": "object"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,15 @@ description = "Voice assistant package"
 readme = "README.md"
 requires-python = ">=3.10"
 
+[project.entry-points."oracolo.stt"]
+local = "OcchioOnniveggente.src.audio:create_local_stt"
+
+[project.entry-points."oracolo.tts"]
+local = "OcchioOnniveggente.src.audio:create_local_tts"
+
+[project.entry-points."oracolo.llm"]
+openai = "OcchioOnniveggente.src.openai_async:create_openai_llm"
+
 [tool.setuptools_scm]
 version_scheme = "guess-next-dev"
 local_scheme = "node-and-date"

--- a/scripts/generate_settings_schema.py
+++ b/scripts/generate_settings_schema.py
@@ -1,0 +1,21 @@
+"""Generate JSON schema for the configuration models."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "OcchioOnniveggente"))
+from src.config import Settings
+
+
+def main() -> None:
+    schema = Settings.model_json_schema()
+    out = Path(__file__).resolve().parents[1] / "docs" / "settings.schema.json"
+    out.write_text(json.dumps(schema, indent=2), encoding="utf-8")
+    print(f"Wrote {out}")
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry
+    main()


### PR DESCRIPTION
## Summary
- add pluggable backends for STT/TTS/LLM via registry and entry points
- expose modular CLI/Web frontends with simple `run()` API
- generate validated config schema and document extension points

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae3a59c3788327b7d6d13626a30108