### PR TITLE
Protect metrics endpoint and document secret management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.egg-info/
+dist/
+build/
+
+# Environment files
+.env
+*.env
+
+# Logs
+data/logs/
+*.log
+*.sqlite
+
+# IDE / editor
+.vscode/
+
+# Misc
+.DS_Store

--- a/OcchioOnniveggente/src/docs_api.py
+++ b/OcchioOnniveggente/src/docs_api.py
@@ -13,11 +13,13 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import FastAPI
+from dotenv import load_dotenv
 from pydantic import BaseModel, Field
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 
 from .metrics import metrics_middleware, metrics_endpoint
 
+load_dotenv()
 app = FastAPI()
 FastAPIInstrumentor.instrument_app(app)
 app.middleware("http")(metrics_middleware)

--- a/OcchioOnniveggente/src/webapp.py
+++ b/OcchioOnniveggente/src/webapp.py
@@ -4,7 +4,8 @@ import asyncio
 import tempfile
 from pathlib import Path
 
-from flask import Flask, render_template, request, jsonify
+from flask import Flask, render_template, request, jsonify, Response as FlaskResponse
+from dotenv import load_dotenv
 
 from .service_container import container
 from .oracle import oracle_answer, transcribe
@@ -14,6 +15,7 @@ from .metrics import metrics_endpoint, health_endpoint
 def create_app() -> Flask:
     """Create and configure the Flask application."""
 
+    load_dotenv()
     app = Flask(__name__, template_folder="templates", static_folder="static")
 
     conv = container.conversation_manager
@@ -53,7 +55,10 @@ def create_app() -> Flask:
 
     @app.get("/metrics")
     def metrics() -> "flask.Response":
-        return metrics_endpoint()
+        resp = metrics_endpoint(request)
+        return FlaskResponse(
+            resp.body, status=resp.status_code, headers=dict(resp.headers), mimetype=resp.media_type
+        )
 
     @app.get("/healthz")
     def health() -> "flask.Response":

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ OcchioOnniveggente/
 └── tests/            # test automatici (pytest)
 ```
 
+## Gestione delle chiavi
+
+Le credenziali richieste (es. `OPENAI_API_KEY`) sono lette da variabili
+d'ambiente. Puoi salvarle in un file `.env` caricato automaticamente con
+`python-dotenv` oppure utilizzare un secret manager esterno. Il file `.env` è
+escluso dal controllo versione per evitare di committare chiavi sensibili.
+
 ## Estensibilità e modularità
 
 ### Plugin backend
@@ -100,6 +107,11 @@ sull'endpoint `/metrics`, interrogabile con strumenti come Prometheus:
 ```bash
 curl http://localhost:8000/metrics
 ```
+
+Per limitare l'accesso è possibile impostare la variabile d'ambiente
+`METRICS_TOKEN` e inviare il relativo bearer token nelle richieste
+(`Authorization: Bearer <token>`). In alternativa proteggi l'endpoint tramite
+un reverse proxy con autenticazione dedicata.
 
 Nel log (livello `DEBUG`) sono visibili gli stessi dati. La funzione
 `resolve_device` utilizza `gpu_utilization_percent` per dirottare le nuove

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,3 +10,4 @@ Benvenuto nella documentazione di **Oracolo**, assistente vocale in italiano e i
 - [Tutorial](tutorials/stt_tts.md)
 - [Deploy](deploy.md)
 - [Versionamento](versioning.md)
+- [Sicurezza](security.md)

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,24 @@
+# Sicurezza e gestione segreti
+
+## Gestione segreti
+
+- Utilizza variabili d'ambiente o un file `.env` (caricato automaticamente con `python-dotenv`).
+- Non inserire mai le chiavi API nel controllo versione: il file `.env` è già escluso tramite `.gitignore`.
+- In produzione preferisci un *secret manager* (ad es. HashiCorp Vault, AWS Secrets Manager) per distribuire le credenziali.
+
+## Best practice
+
+- Limita i permessi delle chiavi API al minimo indispensabile e pianifica una rotazione periodica.
+- Evita di registrare nei log dati sensibili o token: imposta livelli di log appropriati e filtra le informazioni personali.
+- Proteggi i file di configurazione con permessi adeguati e non condividerli su canali insicuri.
+
+## Autenticazione metriche
+
+L'endpoint `/metrics` espone informazioni sull'applicazione e dovrebbe essere protetto. Imposta la variabile d'ambiente `METRICS_TOKEN` per richiedere un *bearer token*:
+
+```bash
+export METRICS_TOKEN=valore-segreto
+```
+
+Le richieste dovranno includere `Authorization: Bearer valore-segreto` oppure il parametro di query `?token=valore-segreto`.
+Per una sicurezza ulteriore integra un reverse proxy (Nginx, Traefik…) con autenticazione OAuth o basata su IP.

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -18,3 +18,14 @@ def test_metrics_endpoint_records_requests():
     resp = client.get("/metrics")
     assert resp.status_code == 200
     assert b"http_requests_total" in resp.content
+
+
+def test_metrics_endpoint_requires_token(monkeypatch):
+    monkeypatch.setenv("METRICS_TOKEN", "s3cr3t")
+    client = TestClient(app)
+
+    resp = client.get("/metrics")
+    assert resp.status_code == 401
+
+    resp = client.get("/metrics", headers={"Authorization": "Bearer s3cr3t"})
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Require optional bearer token for `/metrics` when `METRICS_TOKEN` is set
- Load `.env` in web and docs apps and add guidance on key handling and logging
- Document security best practices and ignore secret files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae3c31f3088327b90df316dbf13f06