### PR TITLE
Improve latency metrics and UI feedback

### DIFF
--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -33,6 +33,7 @@ from .cache import cache_get_json, cache_set_json
 from .rate_limiter import rate_limiter
 from .exceptions import RateLimitExceeded, ExternalServiceError
 from .utils import retry_with_backoff
+from .metrics import pipeline_timer
 
 try:  # pragma: no cover - optional dependency
     from tenacity import retry, stop_after_attempt, wait_exponential
@@ -253,6 +254,7 @@ def _build_instructions(
     return "\n".join(parts)
 
 
+@pipeline_timer("oracle_answer")
 def oracle_answer(
     question: str,
     lang_hint: str,
@@ -372,6 +374,7 @@ def oracle_answer(
     return ans, context or []
 
 
+@pipeline_timer("oracle_answer_async")
 async def oracle_answer_async(
     question: str,
     lang_hint: str,
@@ -412,6 +415,7 @@ async def oracle_answer_async(
     )
 
 
+@pipeline_timer("oracle_answer_stream")
 async def oracle_answer_stream(
     question: str,
     lang_hint: str,

--- a/OcchioOnniveggente/src/ui_theme.py
+++ b/OcchioOnniveggente/src/ui_theme.py
@@ -1,6 +1,23 @@
-THEME = {
-    "bg": "#0f0f0f",
-    "fg": "#00ffe1",
-    "mid": "#161616",
-    "button_bg": "#1e1e1e",
+import os
+
+_THEMES = {
+    "dark": {
+        "bg": "#0f0f0f",
+        "fg": "#00ffe1",
+        "mid": "#161616",
+        "button_bg": "#1e1e1e",
+    },
+    "text": {
+        "bg": "#000000",
+        "fg": "#ffffff",
+        "mid": "#000000",
+        "button_bg": "#000000",
+        "text_only": True,
+    },
 }
+
+
+def get_theme(name: str | None = None) -> dict:
+    """Return theme dictionary by ``name`` or ``ORACOLO_THEME`` env variable."""
+    name = name or os.getenv("ORACOLO_THEME", "dark")
+    return _THEMES.get(name, _THEMES["dark"])


### PR DESCRIPTION
## Summary
- track end-to-end pipeline timing with new Prometheus histogram and decorators
- add GPU utilisation threshold for automatic CPU fallback
- refine UI status/error handling and add selectable themes including text-only mode

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae3ddb6c24832786878df0d7fad943