### PR TITLE
fix: address flake8 lint issues

### DIFF
--- a/OcchioOnniveggente/scripts/convert_to_onnx.py
+++ b/OcchioOnniveggente/scripts/convert_to_onnx.py
@@ -8,10 +8,12 @@ Questo script supporta due tipi di modello:
 Esempi d'uso::
 
     # Esporta un modello transformers in ONNX
-    python scripts/convert_to_onnx.py --model gpt2 --output gpt2.onnx --type llm
+    python scripts/convert_to_onnx.py --model gpt2 --output gpt2.onnx \
+        --type llm
 
     # Esporta un modello Whisper base in ONNX
-    python scripts/convert_to_onnx.py --model base --output whisper-base.onnx --type whisper
+    python scripts/convert_to_onnx.py --model base --output whisper-base.onnx \
+        --type whisper
 """
 
 from __future__ import annotations
@@ -47,10 +49,17 @@ def _convert_whisper(model: str, output: Path) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Converti modelli in ONNX")
-    parser.add_argument("--model", required=True, help="Nome o percorso del modello")
-    parser.add_argument("--output", required=True, help="File ONNX di destinazione")
     parser.add_argument(
-        "--type", choices=["llm", "whisper"], default="llm", help="Tipo di modello"
+        "--model", required=True, help="Nome o percorso del modello"
+    )
+    parser.add_argument(
+        "--output", required=True, help="File ONNX di destinazione"
+    )
+    parser.add_argument(
+        "--type",
+        choices=["llm", "whisper"],
+        default="llm",
+        help="Tipo di modello",
     )
     args = parser.parse_args()
 
@@ -63,4 +72,3 @@ def main() -> None:
 
 if __name__ == "__main__":  # pragma: no cover - script utility
     main()
-

--- a/OcchioOnniveggente/src/docs_api.py
+++ b/OcchioOnniveggente/src/docs_api.py
@@ -8,7 +8,6 @@ metrics endpoint and an option update handler.
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from typing import Any
 

--- a/OcchioOnniveggente/src/event_bus.py
+++ b/OcchioOnniveggente/src/event_bus.py
@@ -1,6 +1,6 @@
-import asyncio
 from collections import defaultdict
-from typing import Any, Callable, Awaitable, Dict, List
+import asyncio
+from typing import Any, Callable, Dict, List
 
 
 class EventBus:
@@ -14,10 +14,12 @@ class EventBus:
     """
 
     def __init__(self) -> None:
-        self._listeners: Dict[str, List[Callable[..., Any]]] = defaultdict(list)
-        self._queue: asyncio.Queue[tuple[str, tuple[Any, ...], dict[str, Any]]] = (
-            asyncio.Queue()
+        self._listeners: Dict[str, List[Callable[..., Any]]] = defaultdict(
+            list
         )
+        self._queue: asyncio.Queue[
+            tuple[str, tuple[Any, ...], dict[str, Any]]
+        ] = asyncio.Queue()
 
     def subscribe(self, event: str, callback: Callable[..., Any]) -> None:
         """Register *callback* to be invoked when *event* is published."""

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -1,12 +1,11 @@
-import json
 import sys
-from types import SimpleNamespace
 from pathlib import Path
+from types import SimpleNamespace
 import numpy as np
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from OcchioOnniveggente.src.chat import ChatState
-from OcchioOnniveggente.src.retrieval import retrieve
+from OcchioOnniveggente.src.chat import ChatState  # noqa: E402
+from OcchioOnniveggente.src.retrieval import retrieve  # noqa: E402
 
 
 class DummyEmbClient:
@@ -14,6 +13,7 @@ class DummyEmbClient:
         class Embeddings:
             def __init__(self, mapping):
                 self.mapping = mapping
+
             def create(self, model, input):
                 data = []
                 for text in input:
@@ -48,8 +48,7 @@ def test_retrieve_filters_by_topic(tmp_path: Path):
     index.write_text(
         '{"documents": ['
         '{"id": "a", "text": "common cat", "topic": "t1"},'
-        '{"id": "b", "text": "common dog", "topic": "t2"}]}'
-    ,
+        '{"id": "b", "text": "common dog", "topic": "t2"}]}',
         encoding="utf-8",
     )
 
@@ -61,4 +60,3 @@ def test_retrieve_filters_by_topic(tmp_path: Path):
     res_all = retrieve("common", index, top_k=5)
     ids_all = {d["id"] for d in res_all}
     assert ids_all == {"a", "b"}
-


### PR DESCRIPTION
## Summary
- wrap long lines and tidy arguments in ONNX conversion script
- drop unused import in docs API and simplify event bus
- clean up topic tests and JSON writing

## Testing
- `flake8 OcchioOnniveggente/scripts/convert_to_onnx.py OcchioOnniveggente/src/docs_api.py OcchioOnniveggente/src/event_bus.py tests/test_topic.py`
- `pytest tests/test_topic.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aedadc991c8327a478c5f741cdabe2