### PR TITLE
refactor: dedupe torch stub and break cycles

### DIFF
--- a/OcchioOnniveggente/src/audio.py
+++ b/OcchioOnniveggente/src/audio.py
@@ -449,7 +449,6 @@ def create_local_tts(container: "ServiceContainer") -> TextToSpeech:
 
 try:  # pragma: no cover - registry may not be available during docs build
     from .plugins import register_stt, register_tts
-    from .service_container import ServiceContainer  # for type checking
 
     register_stt("local", create_local_stt)
     register_tts("local", create_local_tts)

--- a/OcchioOnniveggente/src/cache.py
+++ b/OcchioOnniveggente/src/cache.py
@@ -79,15 +79,12 @@ def cache_set_json(key: str, value: Any, *, ttl: int = 3600) -> None:
 # ---------------------------------------------------------------------------
 
 from .config import Settings  # noqa: E402
+from .utils.container import get_container
 
 
 def _settings() -> Settings:
-    try:
-        from .service_container import container
-
-        return container.settings
-    except Exception:
-        return Settings()
+    container = get_container()
+    return getattr(container, "settings", Settings())
 
 
 def _cache_root() -> Path:

--- a/OcchioOnniveggente/src/conversation.py
+++ b/OcchioOnniveggente/src/conversation.py
@@ -16,6 +16,7 @@ except ImportError:  # pragma: no cover - when ``src`` is top-level
     from DataBase.conversation_store import ConversationStore  # type: ignore
 from .config import Settings, get_openai_api_key
 from .dialogue import DialogueManager, DialogState
+from .utils.container import get_container
 
 
 def summarize_history(prev_summary: str, msgs: List[Dict[str, str]]) -> str:
@@ -39,7 +40,7 @@ def summarize_history(prev_summary: str, msgs: List[Dict[str, str]]) -> str:
     )
 
     if model == "local":
-        from .service_container import container
+        container = get_container()
         try:
             return container.llm_batcher().generate_sync(prompt)
         except Exception:

--- a/OcchioOnniveggente/src/domain.py
+++ b/OcchioOnniveggente/src/domain.py
@@ -76,12 +76,10 @@ def _keyword_overlap_score(text: str, keywords: Iterable[str]) -> float:
     return len(inter) / denom
 
 
+from .utils.math_utils import cosine_similarity
+
+
 # ------------------------- embeddings ------------------------- #
-def _cosine(a: np.ndarray, b: np.ndarray) -> float:
-    na, nb = np.linalg.norm(a), np.linalg.norm(b)
-    if na == 0.0 or nb == 0.0:
-        return 0.0
-    return float(np.dot(a, b) / (na * nb))
 
 
 def _embed_texts(client: Any, model: str, texts: list[str]) -> list[np.ndarray]:
@@ -200,7 +198,7 @@ def _embedding_score(question: str, keywords: list[str], client: Any, model: str
     try:
         vecs = _embed_texts(client, model, [question, " ".join(keywords)])
         if len(vecs) == 2:
-            return _cosine(vecs[0], vecs[1])
+            return cosine_similarity(vecs[0], vecs[1])
     except Exception:
         pass
     return 0.0

--- a/OcchioOnniveggente/src/local_audio.py
+++ b/OcchioOnniveggente/src/local_audio.py
@@ -20,15 +20,17 @@ import soundfile as sf
 import sounddevice as sd
 
 from .cache import get_tts_cache, set_tts_cache
+from types import SimpleNamespace
 
-try:  # pragma: no cover - tests patch this module heavily
-    from .service_container import container  # type: ignore
-except Exception:  # pragma: no cover
-    from types import SimpleNamespace
-    container = SimpleNamespace(
-        load_tts_model=lambda: ("gtts", lambda text, lang: (np.zeros(1), 16000)),
-        load_stt_model=lambda: ("", None),
-    )
+from .utils.container import get_container
+
+
+_container_stub = SimpleNamespace(
+    load_tts_model=lambda: ("gtts", lambda text, lang: (np.zeros(1), 16000)),
+    load_stt_model=lambda: ("", None),
+)
+
+container = get_container(_container_stub)
 
 logger = logging.getLogger(__name__)
 

--- a/OcchioOnniveggente/src/local_llm.py
+++ b/OcchioOnniveggente/src/local_llm.py
@@ -10,9 +10,6 @@ returns the generated text.
 
 
 from typing import Dict, List, Tuple, Literal, Iterator
-from typing import Dict, List
-from .service_container import container
-from typing import Dict, List, Tuple, Literal
 
 
 # simple in-memory cache so that the model is loaded only once
@@ -106,10 +103,6 @@ def generate(
     """
 
     tokenizer, model = _load_model(model_path, device, precision, use_onnx)
-
-
-    tokenizer, model = container.load_llm(model_path, device)
-    tokenizer, model = _load_model(model_path, device, precision)
 
 
 

--- a/OcchioOnniveggente/src/openai_async.py
+++ b/OcchioOnniveggente/src/openai_async.py
@@ -15,18 +15,8 @@ from typing import Callable, TypeVar, Any
 import asyncio
 import os
 import atexit
-try:
-    import torch
-except Exception:  # pragma: no cover
-    class _CudaStub:
-        @staticmethod
-        def is_available() -> bool:
-            return False
 
-    class _TorchStub:
-        cuda = _CudaStub()
-
-    torch = _TorchStub()  # type: ignore
+from .utils.torch_utils import torch
 
 from .config import Settings
 from .utils.device import resolve_device
@@ -142,7 +132,6 @@ def create_openai_llm(container: "ServiceContainer") -> LLMClient:
 
 try:  # pragma: no cover - registry may not be available during docs build
     from .plugins import register_llm
-    from .service_container import ServiceContainer
 
     register_llm("openai", create_openai_llm)
 except Exception:  # pragma: no cover - defensive

--- a/OcchioOnniveggente/src/oracle.py
+++ b/OcchioOnniveggente/src/oracle.py
@@ -27,7 +27,7 @@ from langdetect import LangDetectException, detect  # type: ignore
 from .conversation import ConversationManager, ChatState
 from .retrieval import Question, load_questions, Context
 from .event_bus import event_bus
-from .service_container import container
+from .utils.container import get_container
 from .task_queue import task_queue
 from .cache import cache_get_json, cache_set_json
 from .rate_limiter import rate_limiter
@@ -43,6 +43,7 @@ except Exception:  # pragma: no cover - tenacity not available
 
 logger = logging.getLogger(__name__)
 API_URL = os.getenv("ORACOLO_API_URL")
+container = get_container()
 
 # ---------------------------------------------------------------------------
 # Question dataset utilities

--- a/OcchioOnniveggente/src/realtime_ws.py
+++ b/OcchioOnniveggente/src/realtime_ws.py
@@ -11,7 +11,7 @@ import asyncio, json, os, sys
 import websockets
 
 from src.config import get_openai_api_key
-from .service_container import container
+from .utils.container import get_container
 
 REALTIME_MODEL = os.getenv("REALTIME_MODEL", "gpt-4o-realtime-preview")
 WS_URL = f"wss://api.openai.com/v1/realtime?model={REALTIME_MODEL}"
@@ -23,6 +23,7 @@ async def run(
     conv=None,
     queue: asyncio.Queue | None = None,
 ):
+    container = get_container()
     conv = conv or container.conversation_manager
     queue = queue or container.message_queue
     async with websockets.connect(

--- a/OcchioOnniveggente/src/retrieval.py
+++ b/OcchioOnniveggente/src/retrieval.py
@@ -10,6 +10,7 @@ from enum import Enum
 from typing import List, Dict, Iterable, Optional, Any, Protocol
 
 import numpy as np
+from .utils.math_utils import cosine_similarity
 
 
 try:
@@ -497,15 +498,6 @@ def _make_chunks(text: str, max_chars: int = 800, overlap_ratio: float = 0.1) ->
         if tmp:
             out.append(tmp)
     return out
-
-
-def _cosine(a: np.ndarray, b: np.ndarray) -> float:
-    na, nb = np.linalg.norm(a), np.linalg.norm(b)
-    if na == 0.0 or nb == 0.0:
-        return 0.0
-    return float(np.dot(a, b) / (na * nb))
-
-
 def _embed_texts(
     client: Any, model: str, texts: List[str], *, cache_dir: str | Path | None = None
 ) -> List[np.ndarray]:
@@ -720,7 +712,7 @@ def retrieve(
             qv = _embed_texts(client, embed_model, [query])[0]
             texts = [c.text for c, _ in best]
             vecs = _embed_texts(client, embed_model, texts, cache_dir=cache_dir)
-            sims = [_cosine(qv, v) for v in vecs]
+            sims = [cosine_similarity(qv, v) for v in vecs]
             combo: List[Tuple[Chunk, float]] = []
             for (ch, bm_sc), sim in zip(best, sims):
                 combo.append((ch, 0.5 * bm_sc + 0.5 * sim))

--- a/OcchioOnniveggente/src/service_container.py
+++ b/OcchioOnniveggente/src/service_container.py
@@ -22,18 +22,7 @@ import atexit
 from concurrent.futures import ProcessPoolExecutor
 
 import openai
-try:
-    import torch
-except Exception:  # pragma: no cover
-    class _CudaStub:
-        @staticmethod
-        def is_available() -> bool:
-            return False
-
-    class _TorchStub:
-        cuda = _CudaStub()
-
-    torch = _TorchStub()  # type: ignore
+from .utils.torch_utils import torch
 
 from openai import AsyncOpenAI
 from .config import Settings, get_openai_api_key

--- a/OcchioOnniveggente/src/utils/container.py
+++ b/OcchioOnniveggente/src/utils/container.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+"""Utilities for lazily accessing the service container."""
+
+import importlib
+from types import SimpleNamespace
+from typing import Any
+
+
+def get_container(default: Any | None = None) -> Any:
+    """Return the global ``ServiceContainer`` instance if available.
+
+    Parameters
+    ----------
+    default:
+        Object returned when the container cannot be imported.  By default a
+        simple ``SimpleNamespace`` is provided.
+    """
+    if default is None:
+        default = SimpleNamespace()
+
+    base_pkg = __package__.rsplit(".", 1)[0]
+    try:
+        module = importlib.import_module(f"{base_pkg}.service_container")
+        return getattr(module, "container")
+    except Exception:  # pragma: no cover - container may not exist
+        return default
+
+
+__all__ = ["get_container"]

--- a/OcchioOnniveggente/src/utils/device.py
+++ b/OcchioOnniveggente/src/utils/device.py
@@ -4,26 +4,7 @@ import os
 from typing import Literal
 
 from ..metrics import read_system_metrics
-
-try:
-    import torch  # type: ignore
-except Exception:  # pragma: no cover - torch may be missing
-    class _CudaStub:
-        @staticmethod
-        def is_available() -> bool:
-            return False
-
-        @staticmethod
-        def get_device_properties(_index: int):
-            class _Props:
-                total_memory = 0
-
-            return _Props()
-
-    class _TorchStub:
-        cuda = _CudaStub()
-
-    torch = _TorchStub()  # type: ignore
+from .torch_utils import torch
 
 _MIN_CUDA_GB = int(os.getenv("ORACOLO_MIN_CUDA_GB", "4"))
 _GPU_UTIL_THRESHOLD = float(os.getenv("ORACOLO_GPU_UTIL_THRESHOLD", "90"))

--- a/OcchioOnniveggente/src/utils/math_utils.py
+++ b/OcchioOnniveggente/src/utils/math_utils.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+"""Small mathematical helpers."""
+
+import numpy as np
+
+
+def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
+    """Return the cosine similarity between ``a`` and ``b``."""
+    na, nb = np.linalg.norm(a), np.linalg.norm(b)
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return float(np.dot(a, b) / (na * nb))
+
+
+__all__ = ["cosine_similarity"]

--- a/OcchioOnniveggente/src/utils/torch_utils.py
+++ b/OcchioOnniveggente/src/utils/torch_utils.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""Helpers for working with ``torch`` without a hard dependency."""
+
+try:  # pragma: no cover - torch may be unavailable
+    import torch  # type: ignore
+except Exception:  # pragma: no cover - fallback stub
+    class _CudaStub:
+        @staticmethod
+        def is_available() -> bool:
+            return False
+
+        @staticmethod
+        def get_device_properties(_index: int):
+            class _Props:
+                total_memory = 0
+
+            return _Props()
+
+    class _TorchStub:
+        cuda = _CudaStub()
+
+    torch = _TorchStub()  # type: ignore
+
+__all__ = ["torch"]

--- a/OcchioOnniveggente/src/webapp.py
+++ b/OcchioOnniveggente/src/webapp.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from flask import Flask, render_template, request, jsonify, Response as FlaskResponse
 from dotenv import load_dotenv
 
-from .service_container import container
+from .utils.container import get_container
 from .oracle import oracle_answer, transcribe
 from .metrics import metrics_endpoint, health_endpoint
 
@@ -18,6 +18,7 @@ def create_app() -> Flask:
     load_dotenv()
     app = Flask(__name__, template_folder="templates", static_folder="static")
 
+    container = get_container()
     conv = container.conversation_manager
     queue = container.message_queue
 


### PR DESCRIPTION
## Summary
- add utilities for torch, container lookup and cosine similarity
- refactor modules to reuse utilities and avoid cyclic imports
- centralize device selection logic

## Testing
- `pylint OcchioOnniveggente/src`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aedde8aa0883278e57a9bf867431cd