### PR TITLE
Refactor oracle and UI into modular packages

### DIFF
--- a/OcchioOnniveggente/src/oracle/__init__.py
+++ b/OcchioOnniveggente/src/oracle/__init__.py
@@ -1,0 +1,16 @@
+from .core import *  # noqa: F401,F403
+from .core import __all__ as core_all
+from .questions import get_questions, random_question, _USED_QUESTIONS
+from .offtopic import OFF_TOPIC_RESPONSES, OFF_TOPIC_REPLIES, off_topic_reply
+
+__all__ = (
+    core_all
+    + [
+        "get_questions",
+        "random_question",
+        "_USED_QUESTIONS",
+        "OFF_TOPIC_RESPONSES",
+        "OFF_TOPIC_REPLIES",
+        "off_topic_reply",
+    ]
+)

--- a/OcchioOnniveggente/src/oracle/offtopic.py
+++ b/OcchioOnniveggente/src/oracle/offtopic.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Utility functions and constants for handling off-topic questions."""
+
+from typing import Dict
+
+OFF_TOPIC_RESPONSES: Dict[str, str] = {
+    "poetica": "Preferirei non avventurarmi in slanci poetici.",
+    "didattica": "Al momento non posso fornire spiegazioni didattiche.",
+    "evocativa": "Queste domande evocative sfuggono al mio scopo.",
+    "orientamento": "Non sono in grado di offrire indicazioni stradali.",
+    "default": "Mi dispiace, non posso aiutarti con questa richiesta.",
+}
+
+OFF_TOPIC_REPLIES: Dict[str, str] = {
+    "poetica": "Mi dispiace, ma preferisco non rispondere a richieste poetiche.",
+    "didattica": "Questa domanda sembra didattica e non rientra nel mio ambito.",
+    "evocativa": "Temo che il suo carattere evocativo mi impedisca di rispondere.",
+    "orientamento": "Non posso fornire indicazioni di orientamento in questo contesto.",
+}
+
+
+def off_topic_reply(category: str | None) -> str:
+    """Return a canned reply for an off topic ``category``."""
+
+    if not category:
+        return "Mi dispiace, ma non posso rispondere a questa domanda."
+    return OFF_TOPIC_REPLIES.get(
+        category.lower(), "Mi dispiace, ma non posso rispondere a questa domanda."
+    )
+
+
+__all__ = ["OFF_TOPIC_RESPONSES", "OFF_TOPIC_REPLIES", "off_topic_reply"]

--- a/OcchioOnniveggente/src/oracle/questions.py
+++ b/OcchioOnniveggente/src/oracle/questions.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+"""Utilities for loading and serving questions by category and context."""
+
+from typing import Dict, List
+import random
+
+from ..retrieval import Question, load_questions, Context
+
+# Load questions once at import time. ``load_questions`` may return either a
+# mapping ``{category: [Question, ...]}`` or ``{Context: {category: [...]}}``.
+_loaded = load_questions()
+if _loaded and isinstance(next(iter(_loaded.values())), list):  # type: ignore[arg-type]
+    _QUESTIONS_BY_CONTEXT: Dict[Context, Dict[str, List[Question]]] = {
+        Context.GENERIC: _loaded  # type: ignore[assignment]
+    }
+else:
+    _QUESTIONS_BY_CONTEXT = _loaded  # type: ignore[assignment]
+
+# Track which questions have been served per category to avoid immediate
+# repetitions.
+_USED_QUESTIONS: Dict[str, set[int]] = {}
+
+
+def get_questions(context: Context | str | None = None) -> Dict[str, List[Question]]:
+    """Return questions grouped by category for ``context``."""
+
+    if context is None:
+        ctx = Context.GENERIC
+    elif isinstance(context, Context):
+        ctx = context
+    else:
+        ctx = Context.from_str(context)
+    return _QUESTIONS_BY_CONTEXT.get(ctx, {})
+
+
+def random_question(category: str, context: Context | str | None = None) -> Question | None:
+    """Return a random question from ``category`` without immediate repeats."""
+
+    questions = get_questions(context).get(category, [])
+    if not questions:
+        return None
+
+    used = _USED_QUESTIONS.setdefault(category, set())
+    available = [i for i in range(len(questions)) if i not in used]
+    if not available:
+        used.clear()
+        available = list(range(len(questions)))
+    idx = random.choice(available)
+    used.add(idx)
+    return questions[idx]
+
+
+__all__ = ["get_questions", "random_question", "_USED_QUESTIONS"]

--- a/OcchioOnniveggente/src/ui/__init__.py
+++ b/OcchioOnniveggente/src/ui/__init__.py
@@ -1,0 +1,6 @@
+from .core import *  # noqa: F401,F403
+from .core import __all__ as core_all
+from .realtime_ws import RealtimeWSClient
+from .utils import highlight_terms
+
+__all__ = core_all + ["RealtimeWSClient", "highlight_terms"]

--- a/OcchioOnniveggente/src/ui/core.py
+++ b/OcchioOnniveggente/src/ui/core.py
@@ -43,6 +43,8 @@ from src.ui_state import UIState
 from src.ui_controller import UIController
 from src.ui_controller import UiController, _REASON_RE
 from src.ui_theme import get_theme
+from .realtime_ws import RealtimeWSClient
+from .utils import highlight_terms
 
 THEME = get_theme()
 
@@ -70,257 +72,12 @@ except Exception:  # pragma: no cover - fallback se non disponibile
 WS_URL = os.getenv("ORACOLO_WS_URL", "ws://localhost:8765")
 SR = 24_000
 
-
-def _highlight_terms(text: str, query: str) -> str:
-    """Evidenzia i termini della query all'interno del testo."""
-    tokens = set(re.findall(r"[A-Za-zÀ-ÖØ-öø-ÿ0-9]+", query.lower()))
-    for t in sorted(tokens, key=len, reverse=True):
-        pattern = re.compile(re.escape(t), re.IGNORECASE)
-        text = pattern.sub(lambda m: f"[{m.group(0)}]", text)
-    return text
-
 # opzionale: compatibilità icona PNG via Pillow
 try:
     from PIL import Image, ImageTk  # pip install pillow
 except Exception:
     Image = None
     ImageTk = None
-
-
-# ------------------------- Realtime WS client ---------------------------- #
-class RealtimeWSClient:
-    """Gestisce la connessione WebSocket realtime con audio bidirezionale."""
-
-    def __init__(
-        self,
-        url: str,
-        sr: int,
-        on_partial=lambda text, final: None,
-        on_answer=lambda text: None,
-        *,
-        barge_threshold: float = 500.0,
-        ping_interval: int = 20,
-        ping_timeout: int = 20,
-        auto_reconnect: bool = False,
-        on_input_level=lambda level: None,
-        on_output_level=lambda level: None,
-        on_event=lambda evt: None,
-        on_ping=lambda ms: None,
-        profile_name: str = "museo",
-    ) -> None:
-        self.url = url
-        self.sr = sr
-        self.frame_samples = int(self.sr * 0.02)
-        self.on_partial = on_partial
-        self.on_answer = on_answer
-        self.barge_threshold = barge_threshold
-        self.ping_interval = ping_interval
-        self.ping_timeout = ping_timeout
-        self.auto_reconnect = auto_reconnect
-        self.on_input_level = on_input_level
-        self.on_output_level = on_output_level
-        self.on_event = on_event
-        self.on_ping = on_ping
-        self.profile_name = profile_name
-        self.send_q: "queue.Queue[bytes]" = queue.Queue()
-        self.audio_q: "queue.Queue[bytes]" = queue.Queue()
-        self.state: dict[str, Any] = {
-            "tts_playing": False,
-            "barge_sent": False,
-            "barge_threshold": barge_threshold,
-        }
-        self.loop: asyncio.AbstractEventLoop | None = None
-        self.thread: threading.Thread | None = None
-        self.ws = None
-        self.stop_event: asyncio.Event | None = None
-
-    async def _mic_worker(self) -> None:
-        assert self.ws is not None and self.stop_event is not None
-        loop = asyncio.get_running_loop()
-
-        def callback(indata, frames, time_info, status) -> None:  # type: ignore[override]
-            data = bytes(indata)  # CFFI -> bytes
-
-            if not self.state.get("tts_playing"):
-                self.send_q.put_nowait(data)
-
-            samples = np.frombuffer(data, dtype=np.int16).astype(np.float32)
-            level = float(np.sqrt(np.mean(samples ** 2)))
-            self.on_input_level(level / 32768.0)
-
-            if self.state.get("tts_playing"):
-                if level > self.state.get("barge_threshold", 500.0):
-                    self.state["hot_frames"] = self.state.get("hot_frames", 0) + 1
-                else:
-                    self.state["hot_frames"] = 0
-                now = time.monotonic()
-                if (
-                    self.state.get("hot_frames", 0) >= 10
-                    and not self.state.get("barge_sent", False)
-                    and now - self.state.get("last_barge_ts", 0) > 0.6
-                ):
-                    self.state["barge_sent"] = True
-                    self.state["last_barge_ts"] = now
-                    asyncio.run_coroutine_threadsafe(
-                        self.ws.send(json.dumps({"type": "barge_in"})), loop
-                    )
-
-        with sd.RawInputStream(
-            samplerate=self.sr,
-            blocksize=self.frame_samples,
-            channels=1,
-            dtype="int16",
-            callback=callback,
-            latency="low",
-        ):
-            while not self.stop_event.is_set():
-                await asyncio.sleep(0.1)
-
-    async def _sender(self) -> None:
-        assert self.ws is not None and self.stop_event is not None
-        while not self.stop_event.is_set():
-            data = await asyncio.get_running_loop().run_in_executor(None, self.send_q.get)
-            await self.ws.send(data)
-
-    async def _receiver(self) -> None:
-        assert self.ws is not None and self.stop_event is not None
-        async for msg in self.ws:
-            if isinstance(msg, bytes):
-                self.audio_q.put_nowait(msg)
-                continue
-            try:
-                data = json.loads(msg)
-            except json.JSONDecodeError:
-                continue
-            kind = data.get("type")
-            text = data.get("text", "")
-            if kind == "partial":
-                self.on_partial(text, bool(data.get("final")))
-            elif kind in ("final", "transcript"):
-                self.on_partial(text, True)
-            elif kind == "answer":
-                self.on_answer(text)
-            if self.stop_event.is_set():
-                break
-
-    async def _player(self) -> None:
-        assert self.stop_event is not None
-
-        def callback(outdata, frames, time_info, status) -> None:  # type: ignore[override]
-            try:
-                chunk = self.audio_q.get_nowait()
-                n = len(outdata)
-                vol = 0.3 if self.state.get("barge_sent") else 1.0
-                data = np.frombuffer(chunk, dtype=np.int16).astype(np.float32)
-                data = np.clip(data * vol, -32768, 32767).astype(np.int16).tobytes()
-                if len(data) >= n:
-                    outdata[:] = data[:n]
-                else:
-                    outdata[:len(data)] = data
-                    outdata[len(data):] = b"\x00" * (n - len(data))
-                samples = np.frombuffer(outdata, dtype=np.int16).astype(np.float32)
-                level = float(np.sqrt(np.mean(samples ** 2)))
-                self.on_output_level(level / 32768.0)
-                self.state["tts_playing"] = True
-            except queue.Empty:
-                outdata[:] = b"\x00" * len(outdata)
-                self.state["tts_playing"] = False
-                self.state["barge_sent"] = False
-                self.on_output_level(0.0)
-
-        with sd.RawOutputStream(
-            samplerate=self.sr,
-            blocksize=self.frame_samples,
-            channels=1,
-            dtype="int16",
-            callback=callback,
-        ):
-            while not self.stop_event.is_set():
-                await asyncio.sleep(0.1)
-
-    async def _pinger(self) -> None:
-        assert self.ws is not None and self.stop_event is not None
-        while not self.stop_event.is_set():
-            start = time.perf_counter()
-            try:
-                pong = await self.ws.ping()
-                await pong
-                self.on_ping((time.perf_counter() - start) * 1000)
-            except Exception:
-                break
-            await asyncio.sleep(self.ping_interval)
-
-    async def _run(self) -> None:
-        self.stop_event = asyncio.Event()
-        while not self.stop_event.is_set():
-            try:
-                async with websockets.connect(
-                    self.url, ping_interval=None, ping_timeout=self.ping_timeout
-                ) as ws:
-                    self.ws = ws
-                    self.on_event("connected")
-                    await ws.send(
-                        json.dumps(
-                            {"type": "hello", "sr": self.sr, "format": "pcm_s16le", "channels": 1}
-                        )
-                    )
-                    try:
-                        ready_raw = await asyncio.wait_for(ws.recv(), timeout=10)
-                        data = json.loads(ready_raw) if isinstance(ready_raw, str) else {}
-                        if data.get("type") != "ready":
-                            raise RuntimeError("handshake")
-                    except Exception as e:
-                        self.on_event(f"handshake_error:{e}")
-                        if not self.auto_reconnect:
-                            return
-                        await asyncio.sleep(2)
-                        continue
-
-                    self.on_event("handshake_ok")
-                    try:
-                        await ws.send(json.dumps({"type": "profile", "value": self.profile_name}))
-                    except Exception:
-                        pass
-
-                    tasks = [
-                        asyncio.create_task(self._mic_worker()),
-                        asyncio.create_task(self._sender()),
-                        asyncio.create_task(self._receiver()),
-                        asyncio.create_task(self._player()),
-                        asyncio.create_task(self._pinger()),
-                    ]
-                    await self.stop_event.wait()
-                    for t in tasks:
-                        t.cancel()
-            except Exception as e:
-                self.on_event(f"error:{e}")
-                if not self.auto_reconnect:
-                    break
-                await asyncio.sleep(2)
-            finally:
-                self.ws = None
-            if not self.auto_reconnect:
-                break
-        self.on_event("disconnected")
-
-    def start(self) -> None:
-        if self.thread and self.thread.is_alive():
-            return
-        self.loop = asyncio.new_event_loop()
-        self.thread = threading.Thread(target=self.loop.run_until_complete, args=(self._run(),), daemon=True)
-        self.thread.start()
-
-    def stop(self) -> None:
-        if not self.loop:
-            return
-        if self.stop_event is not None:
-            self.loop.call_soon_threadsafe(self.stop_event.set)
-        if self.ws is not None:
-            asyncio.run_coroutine_threadsafe(self.ws.close(), self.loop)
-        if self.thread and self.thread.is_alive():
-            self.thread.join(timeout=1)
-        self.thread = None
-        self.loop = None
 
 
 # ------------------------------ Orb widget ------------------------------- #
@@ -1383,7 +1140,7 @@ class OracoloUI(tk.Tk):
             )
             toks = q_var.get()
             for i, ch in enumerate(ctx[:k], start=1):
-                text = _highlight_terms(str(ch.get("text", "")), toks)
+                text = highlight_terms(str(ch.get("text", "")), toks)
                 result_box.insert("end", f"[{i}] {text}\n\n")
             self.last_test_result = {
                 "input": question,

--- a/OcchioOnniveggente/src/ui/realtime_ws.py
+++ b/OcchioOnniveggente/src/ui/realtime_ws.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+"""Realtime WebSocket client for bidirectional audio streaming."""
+
+import asyncio
+import json
+import queue
+import threading
+import time
+from typing import Any, Callable
+
+import numpy as np
+import sounddevice as sd
+import websockets
+
+
+class RealtimeWSClient:
+    """Gestisce la connessione WebSocket realtime con audio bidirezionale."""
+
+    def __init__(
+        self,
+        url: str,
+        sr: int,
+        on_partial=lambda text, final: None,
+        on_answer=lambda text: None,
+        *,
+        barge_threshold: float = 500.0,
+        ping_interval: int = 20,
+        ping_timeout: int = 20,
+        auto_reconnect: bool = False,
+        on_input_level=lambda level: None,
+        on_output_level=lambda level: None,
+        on_event=lambda evt: None,
+        on_ping=lambda ms: None,
+        profile_name: str = "museo",
+    ) -> None:
+        self.url = url
+        self.sr = sr
+        self.frame_samples = int(self.sr * 0.02)
+        self.on_partial = on_partial
+        self.on_answer = on_answer
+        self.barge_threshold = barge_threshold
+        self.ping_interval = ping_interval
+        self.ping_timeout = ping_timeout
+        self.auto_reconnect = auto_reconnect
+        self.on_input_level = on_input_level
+        self.on_output_level = on_output_level
+        self.on_event = on_event
+        self.on_ping = on_ping
+        self.profile_name = profile_name
+        self.send_q: "queue.Queue[bytes]" = queue.Queue()
+        self.audio_q: "queue.Queue[bytes]" = queue.Queue()
+        self.state: dict[str, Any] = {
+            "tts_playing": False,
+            "barge_sent": False,
+            "barge_threshold": barge_threshold,
+        }
+        self.loop: asyncio.AbstractEventLoop | None = None
+        self.thread: threading.Thread | None = None
+        self.ws = None
+        self.stop_event: asyncio.Event | None = None
+
+    async def _mic_worker(self) -> None:
+        assert self.ws is not None and self.stop_event is not None
+        loop = asyncio.get_running_loop()
+
+        def callback(indata, frames, time_info, status) -> None:  # type: ignore[override]
+            data = bytes(indata)  # CFFI -> bytes
+
+            if not self.state.get("tts_playing"):
+                self.send_q.put_nowait(data)
+
+            samples = np.frombuffer(data, dtype=np.int16).astype(np.float32)
+            level = float(np.sqrt(np.mean(samples ** 2)))
+            self.on_input_level(level / 32768.0)
+
+            if self.state.get("tts_playing"):
+                if level > self.state.get("barge_threshold", 500.0):
+                    self.state["hot_frames"] = self.state.get("hot_frames", 0) + 1
+                else:
+                    self.state["hot_frames"] = 0
+                now = time.monotonic()
+                if (
+                    self.state.get("hot_frames", 0) >= 10
+                    and not self.state.get("barge_sent", False)
+                    and now - self.state.get("last_barge_ts", 0) > 0.6
+                ):
+                    self.state["barge_sent"] = True
+                    self.state["last_barge_ts"] = now
+                    asyncio.run_coroutine_threadsafe(
+                        self.ws.send(json.dumps({"type": "barge_in"})), loop
+                    )
+
+        with sd.RawInputStream(
+            samplerate=self.sr,
+            blocksize=self.frame_samples,
+            channels=1,
+            dtype="int16",
+            callback=callback,
+            latency="low",
+        ):
+            while not self.stop_event.is_set():
+                await asyncio.sleep(0.1)
+
+    async def _sender(self) -> None:
+        assert self.ws is not None and self.stop_event is not None
+        while not self.stop_event.is_set():
+            data = await asyncio.get_running_loop().run_in_executor(None, self.send_q.get)
+            await self.ws.send(data)
+
+    async def _receiver(self) -> None:
+        assert self.ws is not None and self.stop_event is not None
+        async for msg in self.ws:
+            if isinstance(msg, bytes):
+                self.audio_q.put_nowait(msg)
+                continue
+            try:
+                data = json.loads(msg)
+            except json.JSONDecodeError:
+                continue
+            kind = data.get("type")
+            text = data.get("text", "")
+            if kind == "partial":
+                self.on_partial(text, bool(data.get("final")))
+            elif kind in ("final", "transcript"):
+                self.on_partial(text, True)
+            elif kind == "answer":
+                self.on_answer(text)
+            if self.stop_event.is_set():
+                break
+
+    async def _player(self) -> None:
+        assert self.stop_event is not None
+
+        def callback(outdata, frames, time_info, status) -> None:  # type: ignore[override]
+            try:
+                chunk = self.audio_q.get_nowait()
+                n = len(outdata)
+                vol = 0.3 if self.state.get("barge_sent") else 1.0
+                data = np.frombuffer(chunk, dtype=np.int16).astype(np.float32)
+                data = np.clip(data * vol, -32768, 32767).astype(np.int16).tobytes()
+                if len(data) >= n:
+                    outdata[:] = data[:n]
+                else:
+                    outdata[:len(data)] = data
+                    outdata[len(data):] = b"\x00" * (n - len(data))
+                samples = np.frombuffer(outdata, dtype=np.int16).astype(np.float32)
+                level = float(np.sqrt(np.mean(samples ** 2)))
+                self.on_output_level(level / 32768.0)
+                self.state["tts_playing"] = True
+            except queue.Empty:
+                outdata[:] = b"\x00" * len(outdata)
+                self.state["tts_playing"] = False
+                self.state["barge_sent"] = False
+                self.on_output_level(0.0)
+
+        with sd.RawOutputStream(
+            samplerate=self.sr,
+            blocksize=self.frame_samples,
+            channels=1,
+            dtype="int16",
+            callback=callback,
+        ):
+            while not self.stop_event.is_set():
+                await asyncio.sleep(0.1)
+
+    async def _pinger(self) -> None:
+        assert self.ws is not None and self.stop_event is not None
+        while not self.stop_event.is_set():
+            start = time.perf_counter()
+            try:
+                pong = await self.ws.ping()
+                await pong
+                self.on_ping((time.perf_counter() - start) * 1000)
+            except Exception:
+                break
+            await asyncio.sleep(self.ping_interval)
+
+    async def _run(self) -> None:
+        self.stop_event = asyncio.Event()
+        while not self.stop_event.is_set():
+            try:
+                async with websockets.connect(
+                    self.url, ping_interval=None, ping_timeout=self.ping_timeout
+                ) as ws:
+                    self.ws = ws
+                    self.on_event("connected")
+                    await ws.send(
+                        json.dumps(
+                            {"type": "hello", "sr": self.sr, "format": "pcm_s16le", "channels": 1}
+                        )
+                    )
+                    try:
+                        ready_raw = await asyncio.wait_for(ws.recv(), timeout=10)
+                        data = json.loads(ready_raw) if isinstance(ready_raw, str) else {}
+                        if data.get("type") != "ready":
+                            raise RuntimeError("handshake")
+                    except Exception as e:
+                        self.on_event(f"handshake_error:{e}")
+                        if not self.auto_reconnect:
+                            return
+                        await asyncio.sleep(2)
+                        continue
+
+                    self.on_event("handshake_ok")
+                    try:
+                        await ws.send(json.dumps({"type": "profile", "value": self.profile_name}))
+                    except Exception:
+                        pass
+
+                    tasks = [
+                        asyncio.create_task(self._mic_worker()),
+                        asyncio.create_task(self._sender()),
+                        asyncio.create_task(self._receiver()),
+                        asyncio.create_task(self._player()),
+                        asyncio.create_task(self._pinger()),
+                    ]
+                    await self.stop_event.wait()
+                    for t in tasks:
+                        t.cancel()
+            except Exception as e:
+                self.on_event(f"error:{e}")
+                if not self.auto_reconnect:
+                    break
+                await asyncio.sleep(2)
+            finally:
+                self.ws = None
+            if not self.auto_reconnect:
+                break
+        self.on_event("disconnected")
+
+    def start(self) -> None:
+        if self.thread and self.thread.is_alive():
+            return
+        self.loop = asyncio.new_event_loop()
+        self.thread = threading.Thread(target=self.loop.run_until_complete, args=(self._run(),), daemon=True)
+        self.thread.start()
+
+    def stop(self) -> None:
+        if not self.loop:
+            return
+        if self.stop_event is not None:
+            self.loop.call_soon_threadsafe(self.stop_event.set)
+        if self.ws is not None:
+            asyncio.run_coroutine_threadsafe(self.ws.close(), self.loop)
+        if self.thread and self.thread.is_alive():
+            self.thread.join(timeout=1)
+        self.thread = None
+        self.loop = None

--- a/OcchioOnniveggente/src/ui/utils.py
+++ b/OcchioOnniveggente/src/ui/utils.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+"""Miscellaneous utility helpers for the UI layer."""
+
+import re
+
+
+def highlight_terms(text: str, query: str) -> str:
+    """Highlight terms from ``query`` inside ``text``."""
+    tokens = set(re.findall(r"[A-Za-zÀ-ÖØ-öø-ÿ0-9]+", query.lower()))
+    for t in sorted(tokens, key=len, reverse=True):
+        pattern = re.compile(re.escape(t), re.IGNORECASE)
+        text = pattern.sub(lambda m: f"[{m.group(0)}]", text)
+    return text
+
+
+__all__ = ["highlight_terms"]


### PR DESCRIPTION
## Summary
- split oracle helper into submodules for question handling and off-topic responses
- turn monolithic Tkinter UI into package with reusable WebSocket client and utilities

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af1f4e36d08327b0ebd8bba3402f03