### PR TITLE
fix: resolve realtime_oracolo import conflict

### DIFF
--- a/OcchioOnniveggente/src/realtime_oracolo.py
+++ b/OcchioOnniveggente/src/realtime_oracolo.py
@@ -28,7 +28,6 @@ import sounddevice as sd
 import websockets
 from src.conversation import ConversationManager, DialogState
 from src.retrieval import load_questions
-from src.hardware import local_audio
 from src.audio import local_audio
 from src.oracle import (
     enqueue_generate_reply,


### PR DESCRIPTION
## Summary
- resolve merge conflict in `realtime_oracolo.py` by removing duplicate import and using `src.audio.local_audio`

## Testing
- `pytest -q` *(fails: /workspace/Oracolo/pyproject.toml: Cannot overwrite a value)*

------
https://chatgpt.com/codex/tasks/task_e_68af31cde8b883279fe3b0e6c323ac63