### PR TITLE
refactor: clean up main imports

### DIFF
--- a/OcchioOnniveggente/src/main.py
+++ b/OcchioOnniveggente/src/main.py
@@ -1,53 +1,12 @@
+"""Entry point for the OcchioOnniveggente application."""
+
 from src.app.startup import startup
 from src.app.audio_setup import audio_setup
 from src.app.run import run
 
 
-
-import asyncio
-import numpy as np
-import sounddevice as sd
-import yaml
-from dotenv import load_dotenv
-from openai import AsyncOpenAI
-from pydantic import ValidationError
-import logging
-
-from src.config import Settings, get_openai_api_key
-from src.filters import ProfanityFilter
-from src.hardware.audio import AudioPreprocessor, record_until_silence, play_and_pulse
-from src.hardware.lights import SacnLight, WledLight, color_from_text
-from src.audio.processing import AudioPreprocessor
-from src.audio.recording import record_until_silence, play_and_pulse
-from src.lights import SacnLight, WledLight, color_from_text
-
-from src.oracle import (
-    transcribe,
-    fast_transcribe,
-    oracle_answer,
-    synthesize,
-    append_log,
-    extract_summary,
-    detect_language,
-)
-from src.domain import validate_question
-from src.audio.hotword import is_wake, matches_hotword_text, strip_hotword_prefix
-from src.chat import ChatState
-from src.conversation import ConversationManager, DialogState
-from src.logging_utils import setup_logging
-from src.conversation import update_language
-from src.cli import _ensure_utf8_stdout, say, oracle_greeting, default_response
-from src.hardware.audio_device import pick_device, debug_print_devices
-from src.audio.audio_device import pick_device, debug_print_devices
-from src.profile_utils import get_active_profile, make_domain_settings
-
-logger = logging.getLogger(__name__)
-
-
-
-# --------------------------- main ------------------------------------- #
-
 def main() -> None:
+    """Initialize and run the application."""
     start = startup()
     audio = audio_setup(start.settings, start.debug, start.args)
     run(start, audio)
@@ -55,3 +14,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- simplify entry point by removing unused imports

## Testing
- `ruff --isolated check OcchioOnniveggente/src/main.py`
- `pytest -q` *(fails: ModuleNotFoundError and SyntaxError in tests)*
- `PYTHONPATH=OcchioOnniveggente pytest tests/test_audio_device_module.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af37ad932083278f81e6e404376d14