### PR TITLE
Expose audio helpers via package init

### DIFF
--- a/OcchioOnniveggente/src/audio/__init__.py
+++ b/OcchioOnniveggente/src/audio/__init__.py
@@ -1,0 +1,21 @@
+"""Audio utilities and recording helpers.
+
+This module exposes convenient re-exports so other parts of the project can
+import symbols directly from ``src.audio``.
+"""
+
+from .processing import AudioPreprocessor, apply_agc, apply_limiter, load_audio_as_float
+from .recording import play_and_pulse, record_until_silence, record_wav
+from . import local_audio
+
+__all__ = [
+    "AudioPreprocessor",
+    "apply_agc",
+    "apply_limiter",
+    "load_audio_as_float",
+    "record_until_silence",
+    "play_and_pulse",
+    "record_wav",
+    "local_audio",
+]
+


### PR DESCRIPTION
## Summary
- re-export common audio processing and recording utilities
- expose local audio helpers via package

## Testing
- `pytest tests/test_audio_utils.py -q -c /tmp/pytest.ini`
- `pytest tests/test_audio_device_module.py -q -c /tmp/pytest.ini`
- `PYTHONPATH=. pytest tests/test_audio_missing_sounddevice.py -q -c /tmp/pytest.ini` *(fails: PortAudio library not found)*
- `PYTHONPATH=. pytest tests/test_local_audio_interfaces.py -q -c /tmp/pytest.ini` *(fails: PortAudio library not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af40c1cd4c832781a9155248251c56