### PR TITLE
refactor: update audio imports

### DIFF
--- a/OcchioOnniveggente/src/app/audio_setup.py
+++ b/OcchioOnniveggente/src/app/audio_setup.py
@@ -8,9 +8,9 @@ from typing import Any
 
 import sounddevice as sd
 
-from src.audio import AudioPreprocessor
-from src.audio_device import pick_device, debug_print_devices
-from src.lights import SacnLight, WledLight
+from src.audio.processing import AudioPreprocessor
+from src.audio.audio_device import pick_device, debug_print_devices
+from src.hardware.lights import SacnLight, WledLight
 from src.config import Settings
 
 logger = logging.getLogger(__name__)

--- a/OcchioOnniveggente/src/app/run.py
+++ b/OcchioOnniveggente/src/app/run.py
@@ -16,8 +16,8 @@ import yaml
 import logging
 
 from src.filters import ProfanityFilter
-from src.audio import record_until_silence, play_and_pulse
-from src.lights import color_from_text
+from src.audio.recording import record_until_silence, play_and_pulse
+from src.hardware.lights import color_from_text
 from src.oracle import (
     transcribe,
     fast_transcribe,
@@ -27,10 +27,10 @@ from src.oracle import (
     extract_summary,
     detect_language,
 )
-from src.hotword import is_wake, matches_hotword_text, strip_hotword_prefix
+from src.audio.hotword import is_wake, matches_hotword_text, strip_hotword_prefix
 from src.chat import ChatState
 from src.conversation import ConversationManager, DialogState
-from src.language_session import update_language
+from src.conversation import update_language
 from src.profile_utils import get_active_profile, make_domain_settings
 from src.cli import say, oracle_greeting, default_response
 from src.domain import validate_question


### PR DESCRIPTION
## Summary
- fix audio import paths after package restructuring
- update run and audio setup modules to use new locations

## Testing
- `python -m src.main --help`
- `pytest` *(fails: Cannot overwrite a value (at line 19, column 66))*

------
https://chatgpt.com/codex/tasks/task_e_68af40c248448327b58b5a49fb1dbadc