### PR TITLE
Add OpenAI API key configuration placeholder

### DIFF
--- a/OcchioOnniveggente/settings.yaml
+++ b/OcchioOnniveggente/settings.yaml
@@ -43,15 +43,11 @@ compute:
     
   tts:
     device: auto
-
-openai:
-  # Modello per trascrizione audio (puoi usare anche "whisper-1")
-  stt_model: gpt-4o-mini-transcribe
-
 # Backend STT: "openai" per l'API, "whisper" per modelli locali (faster-whisper, richiede ~4GB VRAM)
 stt_backend: openai
 
 openai:
+  api_key: ""  # Inserisci la tua OpenAI API key oppure usa la variabile d'ambiente OPENAI_API_KEY
   # Modello per trascrizione audio (puoi usare anche "whisper-1")
   stt_model: gpt-4o-mini-transcribe
 


### PR DESCRIPTION
## Summary
- add `openai.api_key` field to `settings.yaml` so the application can read a key from config

## Testing
- `pytest -q` *(fails: /workspace/Oracolo/pyproject.toml: Cannot overwrite a value (at line 19, column 66))*
- `python - <<'PY'
import yaml, pathlib, sys
path = pathlib.Path('OcchioOnniveggente/settings.yaml')
try:
    yaml.safe_load(path.read_text())
    print('YAML OK')
except Exception as e:
    print('YAML ERROR', e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68af437b31e483278a398c02fe8b310f