### PR TITLE
fix ui package import handling

### DIFF
--- a/OcchioOnniveggente/src/ui/__init__.py
+++ b/OcchioOnniveggente/src/ui/__init__.py
@@ -1,6 +1,28 @@
-from .core import *  # noqa: F401,F403
-from .core import __all__ as core_all
-from .realtime_ws import RealtimeWSClient
-from .utils import highlight_terms
+"""Helper exports for the :mod:`src.ui` package.
 
-__all__ = core_all + ["RealtimeWSClient", "highlight_terms"]
+The heavy ``core`` module is intentionally **not** imported here in order to
+avoid circular import issues when ``python -m src.ui.core`` is executed.  Only
+lightweight utilities are re-exported and the main UI should be imported
+explicitly via ``import src.ui.core``.
+"""
+
+from typing import TYPE_CHECKING, Any
+
+__all__ = ["RealtimeWSClient", "highlight_terms"]
+
+if TYPE_CHECKING:  # pragma: no cover - only for type checkers
+    from .realtime_ws import RealtimeWSClient
+    from .utils import highlight_terms
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily import optional helpers."""
+    if name == "RealtimeWSClient":
+        from .realtime_ws import RealtimeWSClient as _RealtimeWSClient
+
+        return _RealtimeWSClient
+    if name == "highlight_terms":
+        from .utils import highlight_terms as _highlight_terms
+
+        return _highlight_terms
+    raise AttributeError(f"module {__name__} has no attribute {name}")


### PR DESCRIPTION
## Summary
- avoid eager imports in `src.ui` package to prevent circular import errors
- lazily expose optional UI utilities

## Testing
- `pytest -q` *(fails: Cannot overwrite a value (at line 19, column 66))*
- `python -m src.ui.core` *(fails: PortAudio library not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af4a13c89c832790bd1c086700c220