### PR TITLE
Fix question loading and validation retrieval

### DIFF
--- a/OcchioOnniveggente/src/retrieval/providers.py
+++ b/OcchioOnniveggente/src/retrieval/providers.py
@@ -57,7 +57,7 @@ def load_questions(path: str | Path | None = None) -> Dict[str, List[Question]]:
     root = (
         Path(path)
         if path is not None
-        else Path(__file__).resolve().parent.parent / "data" / "domande_oracolo.json"
+        else Path(__file__).resolve().parents[2] / "data" / "domande_oracolo.json"
     )
     if root.is_dir():
         root = root / "domande_oracolo.json"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,15 +10,11 @@ readme = "README.md"
 requires-python = ">=3.10"
 
 [project.entry-points."oracolo.stt"]
-
-local = "OcchioOnniveggente.src.hardware.audio:create_local_stt"
-
-[project.entry-points."oracolo.tts"]
-local = "OcchioOnniveggente.src.hardware.audio:create_local_tts"
-
+hardware = "OcchioOnniveggente.src.hardware.audio:create_local_stt"
 local = "OcchioOnniveggente.src.audio.protocols:create_local_stt"
 
 [project.entry-points."oracolo.tts"]
+hardware = "OcchioOnniveggente.src.hardware.audio:create_local_tts"
 local = "OcchioOnniveggente.src.audio.protocols:create_local_tts"
 
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+
+# Expose the real package living under OcchioOnniveggente/src
+_pkg_path = Path(__file__).resolve().parent.parent / 'OcchioOnniveggente' / 'src'
+__path__ = [str(_pkg_path)]

--- a/tests/test_async_tts.py
+++ b/tests/test_async_tts.py
@@ -12,8 +12,7 @@ sys.path.append(str(ROOT))
 sys.path.append(str(ROOT / "OcchioOnniveggente"))
 sys.modules.setdefault("sounddevice", types.SimpleNamespace(play=lambda *a, **k: None, wait=lambda: None))
 
-from OcchioOnniveggente.src.hardware import local_audio
-=======from OcchioOnniveggente.src.audio import local_audio
+from OcchioOnniveggente.src.audio import local_audio
 
 
 

--- a/tests/test_local_audio_interfaces.py
+++ b/tests/test_local_audio_interfaces.py
@@ -6,21 +6,14 @@ import numpy as np
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-
-from OcchioOnniveggente.src.hardware.audio import LocalSpeechToText, LocalTextToSpeech
-
 from OcchioOnniveggente.src.audio.protocols import (
     LocalSpeechToText,
     LocalTextToSpeech,
 )
 
 
-
 def _import_local_audio():
     sys.modules.setdefault("sounddevice", types.SimpleNamespace())
-
-    return importlib.import_module("OcchioOnniveggente.src.hardware.local_audio")
-
     return importlib.import_module("OcchioOnniveggente.src.audio.local_audio")
 
 


### PR DESCRIPTION
## Summary
- expose nested `src` package so test imports work
- clean project entry points and test modules
- fix question loader path and improve retrieval filtering for topic suggestions

## Testing
- `ruff check`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af4ead010c8327a716d99de32014ca