### PR TITLE
Prevent duplicate queue handlers in setup_logging

### DIFF
--- a/OcchioOnniveggente/src/logging_utils.py
+++ b/OcchioOnniveggente/src/logging_utils.py
@@ -89,6 +89,10 @@ def setup_logging(
     queue_handler = QueueHandler(queue)
     root = logging.getLogger()
     root.setLevel(level)
+    # Remove any pre-existing QueueHandler to avoid duplicate logs
+    for handler in list(root.handlers):
+        if isinstance(handler, QueueHandler):
+            root.removeHandler(handler)
     root.addHandler(queue_handler)
 
     if sentry_dsn and sentry_sdk is not None:

--- a/tests/test_structured_logging.py
+++ b/tests/test_structured_logging.py
@@ -23,3 +23,25 @@ def test_setup_logging_produces_json(tmp_path: Path):
     assert data["message"] == "hello"
     assert data["session_id"] == "sess-1"
     assert data["level"] == "INFO"
+
+
+def test_setup_logging_no_duplicate_queue_handlers(tmp_path: Path):
+    prev_factory = logging.getLogRecordFactory()
+    root = logging.getLogger()
+    root.handlers.clear()
+    log_path = tmp_path / "log.json"
+    listener1 = setup_logging(log_path, console=False)
+    root.info("first")
+    listener2 = setup_logging(log_path, console=False)
+    root.info("second")
+    try:
+        pass
+    finally:
+        listener1.stop()
+        listener2.stop()
+        logging.setLogRecordFactory(prev_factory)
+        root.handlers.clear()
+    lines = log_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+    messages = [json.loads(line)["message"] for line in lines]
+    assert messages == ["first", "second"]


### PR DESCRIPTION
## Summary
- remove pre-existing `QueueHandler` instances before adding new one in `setup_logging`
- add regression test ensuring multiple `setup_logging` calls do not duplicate log records

## Testing
- `pytest tests/test_structured_logging.py -q`
- `pytest tests/test_sentry_logging.py tests/test_logging.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af70e5b2ac8327a45accccecd6ab91