### PR TITLE
Normalize context handling in oracle helpers

### DIFF
--- a/OcchioOnniveggente/src/oracle/core.py
+++ b/OcchioOnniveggente/src/oracle/core.py
@@ -140,6 +140,23 @@ def append_log(
 # Language model interaction helpers
 # ---------------------------------------------------------------------------
 
+def _normalize_context(
+    context: Iterable[dict[str, Any] | str] | dict[str, Any] | str | None,
+) -> list[dict[str, Any] | str] | None:
+    """Return ``context`` as a list or ``None``.
+
+    Strings and dictionaries are wrapped in a list. Non-iterables raise
+    ``TypeError`` to provide clearer feedback to callers.
+    """
+    if context is None:
+        return None
+    if isinstance(context, (str, dict)):
+        return [context]
+    try:
+        return list(context)
+    except TypeError:
+        raise TypeError("context must be an iterable of dict or str") from None
+
 def _build_messages(
     question: str,
     context: list[dict[str, Any] | str] | None,
@@ -196,7 +213,7 @@ def oracle_answer(
     llm_model: str | None = None,
     style_prompt: str = "",
     *,
-    context: list[dict[str, Any] | str] | None = None,
+    context: Iterable[dict[str, Any] | str] | dict[str, Any] | str | None = None,
     conv: ConversationManager | None = None,
     mode: str | None = None,
     policy_prompt: str | None = None,
@@ -207,6 +224,8 @@ def oracle_answer(
     off_topic_category: str | None = None,
 ) -> Tuple[str, List[dict[str, Any] | str]]:
     """Return an answer from ``client`` and the context used."""
+    context = _normalize_context(context)
+
     # Check cache first
     cache_key = "oracle:" + hashlib.sha256(question.encode("utf-8")).hexdigest()
     cached = cache_get_json(cache_key)
@@ -316,7 +335,7 @@ async def oracle_answer_async(
     llm_model: str | None = None,
     style_prompt: str = "",
     *,
-    context: list[dict[str, Any] | str] | None = None,
+    context: Iterable[dict[str, Any] | str] | dict[str, Any] | str | None = None,
     conv: ConversationManager | None = None,
     mode: str | None = None,
     policy_prompt: str | None = None,
@@ -327,6 +346,7 @@ async def oracle_answer_async(
     off_topic_category: str | None = None,
 ) -> Tuple[str, List[dict[str, Any] | str]]:
     """Async wrapper around :func:`oracle_answer` using ``asyncio.to_thread``."""
+    context = _normalize_context(context)
     client = client or container.llm_client()
     llm_model = llm_model or container.settings.openai.llm_model
 
@@ -357,12 +377,13 @@ async def oracle_answer_stream(
     llm_model: str | None = None,
     style_prompt: str = "",
     *,
-    context: list[dict[str, Any] | str] | None = None,
+    context: Iterable[dict[str, Any] | str] | dict[str, Any] | str | None = None,
     mode: str | None = None,
     policy_prompt: str | None = None,
     conv: ConversationManager | None = None,
 ) -> AsyncGenerator[Tuple[str, bool], None]:
     """Async generator yielding response chunks and completion flag."""
+    context = _normalize_context(context)
     if API_URL:
         resp = requests.post(
             f"{API_URL}/chat",

--- a/tests/test_oracle_answer.py
+++ b/tests/test_oracle_answer.py
@@ -73,6 +73,37 @@ def test_oracle_answer_handles_string_context():
     assert any("nota di contesto" in m.get("content", "") for m in messages)
 
 
+def test_oracle_answer_accepts_single_string_context():
+    client = DummyClient()
+    ans, ctx = oracle_answer(
+        question="Che cos'è?",
+        lang_hint="it",
+        client=client,
+        llm_model="test-model",
+        context="nota singola",
+    )
+    assert ans == "risposta"
+    assert ctx == ["nota singola"]
+    _, _, messages = client.responses.called_with
+    assert any("nota singola" in m.get("content", "") for m in messages)
+
+
+def test_oracle_answer_accepts_single_dict_context():
+    client = DummyClient()
+    ctx_item = {"text": "fonte"}
+    ans, ctx = oracle_answer(
+        question="Che cos'è?",
+        lang_hint="it",
+        client=client,
+        llm_model="test-model",
+        context=ctx_item,
+    )
+    assert ans == "risposta"
+    assert ctx == [ctx_item]
+    _, _, messages = client.responses.called_with
+    assert any("fonte" in m.get("content", "") for m in messages)
+
+
 def test_answer_and_log_followup(tmp_path: Path):
     client = DummyClient()
     qdata = Question(id="1", domanda="Chi sei?", type="poetica", follow_up="Vuoi continuare?")


### PR DESCRIPTION
## Summary
- add `_normalize_context` helper to wrap single string/dict and validate iterables
- apply context normalization in `oracle_answer` and async helpers
- cover single string/dict context inputs with regression tests

## Testing
- `pytest tests/test_oracle_answer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af70e5b444832797fba491f47b7c39