### PR TITLE
Add embedding timeout and retry logic

### DIFF
--- a/tests/test_embed_timeout.py
+++ b/tests/test_embed_timeout.py
@@ -1,0 +1,24 @@
+from types import SimpleNamespace
+from pathlib import Path
+import sys
+import time
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from src.retrieval import _embed_texts  # noqa: E402
+
+
+class StallEmbClient:
+    class Embeddings:
+        def create(self, model, input):  # noqa: D401
+            time.sleep(1)
+            return SimpleNamespace(data=[])
+
+    def __init__(self):
+        self.embeddings = self.Embeddings()
+
+
+def test_embed_timeout(tmp_path: Path):
+    client = StallEmbClient()
+    with pytest.raises(TimeoutError):
+        _embed_texts(client, "m", ["ciao"], timeout=0.1, retries=1)


### PR DESCRIPTION
## Summary
- enforce timeout and retries when fetching embeddings, raising a clear error on stalls
- add test for embedding timeout handling

## Testing
- `pytest tests/test_embed_cache.py tests/test_embed_timeout.py`


------
https://chatgpt.com/codex/tasks/task_e_68af70e7f40883278caac0a2ed795f1d